### PR TITLE
refactor: extract QGIS algorithm catalog into dedicated store and utility modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arion",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Arion is an AI agentic desktop application for geospatial analysis.",
   "license": "GPL-3.0-or-later",
   "main": "./out/main/index.js",

--- a/src/main/database/migrations/add-qgis-algorithm-catalog-cache.sql
+++ b/src/main/database/migrations/add-qgis-algorithm-catalog-cache.sql
@@ -1,0 +1,144 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS qgis_catalog_schema_migrations (
+  version TEXT PRIMARY KEY,
+  applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS qgis_algorithm_catalogs (
+  cache_key TEXT PRIMARY KEY,
+  launcher_path TEXT NOT NULL,
+  version TEXT,
+  allow_plugin_algorithms INTEGER NOT NULL DEFAULT 0,
+  built_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS qgis_algorithm_entries (
+  cache_key TEXT NOT NULL,
+  id TEXT NOT NULL,
+  name TEXT,
+  provider TEXT,
+  supported_for_execution INTEGER NOT NULL DEFAULT 0,
+  summary TEXT,
+  parameter_names TEXT NOT NULL DEFAULT '[]',
+  parameter_types TEXT NOT NULL DEFAULT '[]',
+  parameter_descriptions TEXT NOT NULL DEFAULT '[]',
+  required_parameter_names TEXT NOT NULL DEFAULT '[]',
+  output_parameter_names TEXT NOT NULL DEFAULT '[]',
+  help_fetched_at TEXT,
+  raw_help_preview TEXT,
+  sort_name TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (cache_key, id),
+  FOREIGN KEY (cache_key) REFERENCES qgis_algorithm_catalogs(cache_key) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_qgis_algorithm_entries_cache_key
+  ON qgis_algorithm_entries(cache_key);
+
+CREATE INDEX IF NOT EXISTS idx_qgis_algorithm_entries_cache_provider
+  ON qgis_algorithm_entries(cache_key, provider);
+
+CREATE INDEX IF NOT EXISTS idx_qgis_algorithm_entries_cache_sort_name
+  ON qgis_algorithm_entries(cache_key, sort_name, id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS qgis_algorithm_entries_fts USING fts5(
+  cache_key UNINDEXED,
+  id,
+  name,
+  provider,
+  summary,
+  parameter_names,
+  required_parameter_names,
+  output_parameter_names,
+  parameter_types,
+  parameter_descriptions,
+  raw_help_preview,
+  supported UNINDEXED,
+  sort_name UNINDEXED,
+  tokenize = 'unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER IF NOT EXISTS qgis_algorithm_entries_ai
+AFTER INSERT ON qgis_algorithm_entries
+BEGIN
+  INSERT INTO qgis_algorithm_entries_fts (
+    rowid,
+    cache_key,
+    id,
+    name,
+    provider,
+    summary,
+    parameter_names,
+    required_parameter_names,
+    output_parameter_names,
+    parameter_types,
+    parameter_descriptions,
+    raw_help_preview,
+    supported,
+    sort_name
+  )
+  VALUES (
+    NEW.rowid,
+    NEW.cache_key,
+    COALESCE(NEW.id, ''),
+    COALESCE(NEW.name, ''),
+    COALESCE(NEW.provider, ''),
+    COALESCE(NEW.summary, ''),
+    COALESCE(NEW.parameter_names, ''),
+    COALESCE(NEW.required_parameter_names, ''),
+    COALESCE(NEW.output_parameter_names, ''),
+    COALESCE(NEW.parameter_types, ''),
+    COALESCE(NEW.parameter_descriptions, ''),
+    COALESCE(NEW.raw_help_preview, ''),
+    CASE WHEN NEW.supported_for_execution = 1 THEN '1' ELSE '0' END,
+    COALESCE(NEW.sort_name, '')
+  );
+END;
+
+CREATE TRIGGER IF NOT EXISTS qgis_algorithm_entries_ad
+AFTER DELETE ON qgis_algorithm_entries
+BEGIN
+  DELETE FROM qgis_algorithm_entries_fts WHERE rowid = OLD.rowid;
+END;
+
+CREATE TRIGGER IF NOT EXISTS qgis_algorithm_entries_au
+AFTER UPDATE ON qgis_algorithm_entries
+BEGIN
+  DELETE FROM qgis_algorithm_entries_fts WHERE rowid = OLD.rowid;
+  INSERT INTO qgis_algorithm_entries_fts (
+    rowid,
+    cache_key,
+    id,
+    name,
+    provider,
+    summary,
+    parameter_names,
+    required_parameter_names,
+    output_parameter_names,
+    parameter_types,
+    parameter_descriptions,
+    raw_help_preview,
+    supported,
+    sort_name
+  )
+  VALUES (
+    NEW.rowid,
+    NEW.cache_key,
+    COALESCE(NEW.id, ''),
+    COALESCE(NEW.name, ''),
+    COALESCE(NEW.provider, ''),
+    COALESCE(NEW.summary, ''),
+    COALESCE(NEW.parameter_names, ''),
+    COALESCE(NEW.required_parameter_names, ''),
+    COALESCE(NEW.output_parameter_names, ''),
+    COALESCE(NEW.parameter_types, ''),
+    COALESCE(NEW.parameter_descriptions, ''),
+    COALESCE(NEW.raw_help_preview, ''),
+    CASE WHEN NEW.supported_for_execution = 1 THEN '1' ELSE '0' END,
+    COALESCE(NEW.sort_name, '')
+  );
+END;
+
+INSERT OR IGNORE INTO qgis_catalog_schema_migrations (version)
+VALUES ('add-qgis-algorithm-catalog-cache-v1');

--- a/src/main/llm-tools/integration-tools/qgis-describe-algorithm-tool.ts
+++ b/src/main/llm-tools/integration-tools/qgis-describe-algorithm-tool.ts
@@ -12,6 +12,6 @@ export type QgisDescribeAlgorithmParams = z.infer<typeof QgisDescribeAlgorithmPa
 
 export const qgisDescribeAlgorithmToolDefinition = {
   description:
-    'Describes a QGIS Processing algorithm, including its exact parameter names, accepted value shapes, and output expectations. Use this before qgis_run_processing when you need to build the `parameters` object correctly or chain several QGIS processing steps into one analysis workflow.',
+    'Describes a QGIS Processing algorithm, including its exact parameter names, accepted value shapes, and output expectations. Use this after qgis_list_algorithms when you want to compare a few plausible candidates or before qgis_run_processing when you need to build the `parameters` object correctly.',
   inputSchema: QgisDescribeAlgorithmParamsSchema
 }

--- a/src/main/llm-tools/integration-tools/qgis-list-algorithms-tool.ts
+++ b/src/main/llm-tools/integration-tools/qgis-list-algorithms-tool.ts
@@ -11,7 +11,7 @@ export const QgisListAlgorithmsParamsSchema = z.object({
     .max(200)
     .optional()
     .describe(
-      'Optional natural-language task phrase used to rank QGIS algorithms by relevance. Prefer describing the next atomic step, such as "sort line features by length descending", "extract features matching an expression", "clip parcels to a boundary", or "join polygons by attribute", instead of sending only a vague keyword. For multi-step tasks like "top 10 longest lines", search the ranking step first, then search the extraction step if needed.'
+      'Optional natural-language search phrase for the next atomic QGIS step. Start with a concise task description such as "sort line features by length descending", "extract features matching an expression", "clip parcels to a boundary", or "join polygons by attribute". If the shortlist is weak or ambiguous, retry with alternate phrasings or exact words from candidate algorithm names before choosing an algorithm id.'
     ),
   provider: z
     .string()
@@ -38,6 +38,6 @@ export type QgisListAlgorithmsParams = z.infer<typeof QgisListAlgorithmsParamsSc
 
 export const qgisListAlgorithmsToolDefinition = {
   description:
-    'Lists QGIS Processing algorithms available through the configured local QGIS installation and ranks them using a cached structured catalog built from QGIS metadata. Use this to discover likely algorithm candidates before qgis_describe_algorithm or qgis_run_processing. Prefer using `query`, `provider`, and `limit` to get a relevant shortlist instead of requesting the full catalog. For compound workflows, search the immediate step you are about to run, not the whole workflow at once.',
+    'Searches QGIS Processing algorithms available through the configured local QGIS installation using cached factual metadata from QGIS itself, including ids, names, help summaries, and parameter details when available. Use this iteratively to discover plausible algorithm ids before qgis_describe_algorithm or qgis_run_processing. Prefer searching the immediate step you are about to run, keep the shortlist small with `limit`, and if the first search is ambiguous, refine the query and search again instead of guessing.',
   inputSchema: QgisListAlgorithmsParamsSchema
 }

--- a/src/main/services/qgis/qgis-algorithm-catalog-service.test.ts
+++ b/src/main/services/qgis/qgis-algorithm-catalog-service.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { promises as fs } from 'fs'
 import os from 'os'
 import path from 'path'
@@ -18,6 +19,11 @@ vi.mock('./qgis-command-runner', () => ({
 }))
 
 import { QgisAlgorithmCatalogService } from './qgis-algorithm-catalog-service'
+import { QgisAlgorithmCatalogStore } from './qgis-algorithm-catalog-store'
+import { createQgisSqliteDatabase } from './qgis-sqlite'
+
+const CATALOG_DB_PATH = (rootPath: string): string =>
+  path.join(rootPath, 'qgis-algorithm-catalogs', 'qgis-algorithm-catalogs.sqlite')
 
 describe('QgisAlgorithmCatalogService', () => {
   let tempRoot: string
@@ -145,25 +151,46 @@ describe('QgisAlgorithmCatalogService', () => {
       id: 'native:orderbyexpression'
     })
     expect(result?.algorithms[0]?.summary).toContain('Sorts features according to an expression')
-    expect(result?.algorithms[0]?.categoryHints).toContain('sorting')
+    expect(result?.algorithms[0]?.parameterNames).toEqual([
+      'INPUT',
+      'EXPRESSION',
+      'ASCENDING',
+      'OUTPUT'
+    ])
     expect(result?.catalog?.enrichedEntries).toBeGreaterThan(0)
 
-    const catalogDirectory = path.join(tempRoot, 'qgis-algorithm-catalogs')
-    const cachedFiles = await fs.readdir(catalogDirectory)
-    expect(cachedFiles).toHaveLength(1)
+    const databasePath = CATALOG_DB_PATH(tempRoot)
+    await expect(fs.stat(databasePath)).resolves.toBeTruthy()
 
-    const cachedCatalog = JSON.parse(
-      await fs.readFile(path.join(catalogDirectory, cachedFiles[0]), 'utf8')
-    ) as {
-      entries: Array<{ id: string; helpFetchedAt?: string; parameterNames?: string[] }>
+    const db = createQgisSqliteDatabase(databasePath)
+    try {
+      const row = db
+        .prepare(
+          `SELECT help_fetched_at, parameter_names, parameter_types, parameter_descriptions
+           FROM qgis_algorithm_entries
+           WHERE id = ?`
+        )
+        .get('native:orderbyexpression') as {
+        help_fetched_at: string | null
+        parameter_names: string
+        parameter_types: string
+        parameter_descriptions: string
+      }
+
+      expect(row).toMatchObject({
+        help_fetched_at: expect.any(String),
+        parameter_names: JSON.stringify(['INPUT', 'EXPRESSION', 'ASCENDING', 'OUTPUT']),
+        parameter_types: JSON.stringify(['boolean', 'expression', 'sink', 'vector']),
+        parameter_descriptions: JSON.stringify([
+          'Ascending order flag',
+          'Expression used for ordering',
+          'Input line layer',
+          'Sorted output layer'
+        ])
+      })
+    } finally {
+      db.close()
     }
-
-    expect(
-      cachedCatalog.entries.find((entry) => entry.id === 'native:orderbyexpression')
-    ).toMatchObject({
-      helpFetchedAt: expect.any(String),
-      parameterNames: ['INPUT', 'EXPRESSION', 'ASCENDING', 'OUTPUT']
-    })
   })
 
   it('warms the base catalog from the QGIS list output', async () => {
@@ -211,19 +238,113 @@ describe('QgisAlgorithmCatalogService', () => {
       allowPluginAlgorithms: false
     })
 
-    const catalogDirectory = path.join(tempRoot, 'qgis-algorithm-catalogs')
-    const cachedFiles = await fs.readdir(catalogDirectory)
-    expect(cachedFiles).toHaveLength(1)
+    const db = createQgisSqliteDatabase(CATALOG_DB_PATH(tempRoot))
+    try {
+      const rows = db.prepare('SELECT id FROM qgis_algorithm_entries ORDER BY id').all() as Array<{
+        id: string
+      }>
 
-    const cachedCatalog = JSON.parse(
-      await fs.readFile(path.join(catalogDirectory, cachedFiles[0]), 'utf8')
-    ) as {
-      entries: Array<{ id: string }>
+      expect(rows.map((entry) => entry.id)).toEqual(['native:buffer', 'native:extractbyexpression'])
+    } finally {
+      db.close()
+    }
+  })
+
+  it('warms the base catalog from provider-scoped QGIS JSON output and rebuilds an empty catalog', async () => {
+    const launcherPath = 'D:\\Program Files\\QGIS 3.36.2\\bin\\qgis_process-qgis.bat'
+    const version = '3.36.2-Maidenhead'
+    const cacheKey = createHash('sha1')
+      .update(
+        JSON.stringify({
+          schemaVersion: 2,
+          launcherPath,
+          version,
+          allowPluginAlgorithms: false
+        })
+      )
+      .digest('hex')
+
+    await fs.mkdir(path.dirname(CATALOG_DB_PATH(tempRoot)), { recursive: true })
+    new QgisAlgorithmCatalogStore(CATALOG_DB_PATH(tempRoot)).readCatalog(cacheKey)
+
+    const db = createQgisSqliteDatabase(CATALOG_DB_PATH(tempRoot))
+    try {
+      db.prepare(
+        `INSERT INTO qgis_algorithm_catalogs (
+           cache_key,
+           launcher_path,
+           version,
+           allow_plugin_algorithms,
+           built_at,
+           updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run(
+        cacheKey,
+        launcherPath,
+        version,
+        0,
+        '2026-03-25T22:26:11.980Z',
+        '2026-03-25T22:26:11.980Z'
+      )
+    } finally {
+      db.close()
     }
 
-    expect(cachedCatalog.entries.map((entry) => entry.id)).toEqual([
-      'native:buffer',
-      'native:extractbyexpression'
-    ])
+    runQgisLauncherCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        providers: {
+          native: {
+            algorithms: {
+              'native:buffer': {
+                name: 'Buffer'
+              },
+              'native:orderbyexpression': {
+                name: 'Order by expression'
+              }
+            }
+          }
+        }
+      }),
+      stderr: '',
+      exitCode: 0,
+      durationMs: 12
+    })
+
+    const service = new QgisAlgorithmCatalogService({
+      discoveryService: {
+        discover: vi.fn(async () => ({
+          status: 'found',
+          preferredInstallation: {
+            launcherPath,
+            installRoot: 'D:\\Program Files\\QGIS 3.36.2',
+            version,
+            platform: process.platform,
+            source: 'manual',
+            diagnostics: []
+          },
+          installations: [],
+          diagnostics: []
+        }))
+      } as never,
+      getUserDataPath: () => tempRoot
+    })
+
+    await service.warmCatalog({
+      detectionMode: 'auto',
+      allowPluginAlgorithms: false
+    })
+
+    const rebuiltDb = createQgisSqliteDatabase(CATALOG_DB_PATH(tempRoot))
+    try {
+      const rows = rebuiltDb
+        .prepare('SELECT id FROM qgis_algorithm_entries ORDER BY id')
+        .all() as Array<{
+        id: string
+      }>
+
+      expect(rows.map((entry) => entry.id)).toEqual(['native:buffer', 'native:orderbyexpression'])
+    } finally {
+      rebuiltDb.close()
+    }
   })
 })

--- a/src/main/services/qgis/qgis-algorithm-catalog-service.ts
+++ b/src/main/services/qgis/qgis-algorithm-catalog-service.ts
@@ -1,49 +1,24 @@
 import { createHash } from 'crypto'
-import { promises as fs } from 'fs'
 import path from 'path'
 import { app } from 'electron'
 import type { QgisDiscoveredInstallation, QgisIntegrationConfig } from '../../../shared/ipc-types'
-import { isQgisAlgorithmApproved } from './qgis-algorithm-policy'
+import {
+  QgisAlgorithmCatalogStore,
+  type StoredQgisAlgorithmCatalog,
+  type StoredQgisAlgorithmCatalogEntry
+} from './qgis-algorithm-catalog-store'
+import { normalizeQgisAlgorithmList } from './qgis-algorithm-list'
 import { runQgisLauncherCommand } from './qgis-command-runner'
 import { QgisDiscoveryService } from './qgis-discovery-service'
 
-const CATALOG_SCHEMA_VERSION = 1
+const CATALOG_SCHEMA_VERSION = 2
 const CATALOG_DIRECTORY_NAME = 'qgis-algorithm-catalogs'
+const CATALOG_DATABASE_FILENAME = 'qgis-algorithm-catalogs.sqlite'
 const MAX_ENRICH_PER_QUERY = 10
 const MAX_CONCURRENT_HELP_REQUESTS = 3
 const DEFAULT_HELP_TIMEOUT_MS = 8_000
 const MAX_HELP_PREVIEW_LENGTH = 2_000
 const OUTPUT_KEY_PATTERN = /(output|destination|dest|sink|file)$/i
-const STOPWORDS = new Set([
-  'a',
-  'an',
-  'and',
-  'are',
-  'as',
-  'at',
-  'be',
-  'by',
-  'for',
-  'from',
-  'how',
-  'if',
-  'in',
-  'into',
-  'is',
-  'it',
-  'of',
-  'on',
-  'or',
-  'that',
-  'the',
-  'their',
-  'then',
-  'this',
-  'to',
-  'use',
-  'using',
-  'with'
-])
 
 interface QgisAlgorithmListEntry {
   id: string
@@ -62,15 +37,13 @@ interface QgisAlgorithmParameterRecord {
 
 export interface QgisAlgorithmCatalogEntry extends QgisAlgorithmListEntry {
   summary?: string
-  categoryHints?: string[]
-  geometryHints?: string[]
-  layerTypeHints?: string[]
   parameterNames: string[]
+  parameterTypes: string[]
+  parameterDescriptions: string[]
   requiredParameterNames: string[]
   outputParameterNames: string[]
   helpFetchedAt?: string
   rawHelpPreview?: string
-  searchTerms: string[]
 }
 
 interface QgisAlgorithmCatalogFile {
@@ -86,7 +59,7 @@ interface QgisAlgorithmCatalogFile {
 
 interface QgisAlgorithmCatalogContext {
   cacheKey: string
-  cachePath: string
+  databasePath: string
   installation: QgisDiscoveredInstallation
   allowPluginAlgorithms: boolean
 }
@@ -106,9 +79,6 @@ export type RankAlgorithmsResult = {
   algorithms: Array<
     QgisAlgorithmListEntry & {
       summary?: string
-      categoryHints?: string[]
-      geometryHints?: string[]
-      layerTypeHints?: string[]
       parameterNames?: string[]
       requiredParameterNames?: string[]
       outputParameterNames?: string[]
@@ -180,34 +150,36 @@ export class QgisAlgorithmCatalogService {
     )
 
     if (query) {
-      const candidatesToEnrich = preliminaryRecords
-        .map((entry) => ({
-          entry,
-          score: scoreAlgorithmEntry(entry, query)
-        }))
-        .sort(compareScoredEntries)
-        .filter(({ entry }) => !entry.helpFetchedAt)
+      const candidatesToEnrich = this.getCatalogStore(context.databasePath)
+        .searchCatalogEntries(context.cacheKey, query, {
+          provider,
+          limit: MAX_ENRICH_PER_QUERY * 4
+        })
+        .map(({ entry }) => entry)
+        .filter((entry) => !entry.helpFetchedAt)
         .slice(0, MAX_ENRICH_PER_QUERY)
-        .map(({ entry }) => entry.id)
+        .map((entry) => entry.id)
 
       if (candidatesToEnrich.length > 0) {
         await this.enrichCatalogEntries(context, candidatesToEnrich, input.timeoutMs)
-        catalog = (await this.readCatalog(context.cachePath)) ?? catalog
+        catalog = (await this.readCatalog(context)) ?? catalog
       }
     }
 
-    const rankedRecords = catalog.entries
-      .filter((entry) =>
-        provider
-          ? (entry.provider || entry.id.split(':')[0] || '').toLowerCase() === provider
-          : true
-      )
-      .map((entry) => ({
-        entry,
-        score: query ? scoreAlgorithmEntry(entry, query) : 0
-      }))
-      .filter(({ score }) => !query || score > 0)
-      .sort(compareScoredEntries)
+    const rankedRecords = query
+      ? this.getCatalogStore(context.databasePath)
+          .searchCatalogEntries(context.cacheKey, query, {
+            provider,
+            limit: Math.max(preliminaryRecords.length, limit)
+          })
+          .map(({ entry, relevance }) => ({
+            entry: entry as QgisAlgorithmCatalogEntry,
+            score: relevance
+          }))
+      : preliminaryRecords.map((entry) => ({
+          entry,
+          score: 0
+        }))
 
     const limitedRecords = rankedRecords.slice(0, limit)
     const resultAlgorithms = limitedRecords.map(({ entry, score }) => ({
@@ -216,9 +188,6 @@ export class QgisAlgorithmCatalogService {
       provider: entry.provider,
       supportedForExecution: entry.supportedForExecution,
       summary: entry.summary,
-      categoryHints: entry.categoryHints,
-      geometryHints: entry.geometryHints,
-      layerTypeHints: entry.layerTypeHints,
       parameterNames: entry.parameterNames,
       requiredParameterNames: entry.requiredParameterNames,
       outputParameterNames: entry.outputParameterNames,
@@ -250,8 +219,8 @@ export class QgisAlgorithmCatalogService {
     context: QgisAlgorithmCatalogContext,
     seedAlgorithms?: QgisAlgorithmListEntry[]
   ): Promise<QgisAlgorithmCatalogFile | null> {
-    const existingCatalog = await this.readCatalog(context.cachePath)
-    if (existingCatalog) {
+    const existingCatalog = await this.readCatalog(context)
+    if (existingCatalog && existingCatalog.entries.length > 0) {
       return seedAlgorithms
         ? await this.mergeSeedAlgorithms(context, existingCatalog, seedAlgorithms)
         : existingCatalog
@@ -272,7 +241,7 @@ export class QgisAlgorithmCatalogService {
         return null
       }
 
-      await this.writeCatalog(context.cachePath, catalog)
+      await this.writeCatalog(context, catalog)
       return catalog
     })().finally(() => {
       this.baseCatalogTasks.delete(context.cacheKey)
@@ -310,7 +279,6 @@ export class QgisAlgorithmCatalogService {
         existingEntry.name = algorithm.name
         existingEntry.provider = algorithm.provider
         existingEntry.supportedForExecution = algorithm.supportedForExecution
-        existingEntry.searchTerms = buildSearchTerms(existingEntry)
         hasChanges = true
       }
     }
@@ -324,7 +292,7 @@ export class QgisAlgorithmCatalogService {
       updatedAt: new Date().toISOString(),
       entries: Array.from(entryById.values()).sort(compareCatalogEntries)
     }
-    await this.writeCatalog(context.cachePath, nextCatalog)
+    await this.writeCatalog(context, nextCatalog)
     return nextCatalog
   }
 
@@ -346,11 +314,9 @@ export class QgisAlgorithmCatalogService {
     }
 
     const parsedResult = safeParseJson(result.stdout)
-    const algorithms = normalizeAlgorithmList(
-      parsedResult,
-      result.stdout,
-      context.allowPluginAlgorithms
-    )
+    const algorithms = normalizeQgisAlgorithmList(parsedResult, result.stdout, {
+      allowPluginAlgorithms: context.allowPluginAlgorithms
+    }).algorithms
     return createCatalogFile(context, algorithms)
   }
 
@@ -373,7 +339,7 @@ export class QgisAlgorithmCatalogService {
     }
 
     const task = (async () => {
-      const catalog = await this.readCatalog(context.cachePath)
+      const catalog = await this.readCatalog(context)
       if (!catalog) {
         return
       }
@@ -421,7 +387,7 @@ export class QgisAlgorithmCatalogService {
         updatedAt: new Date().toISOString(),
         entries: Array.from(entryById.values()).sort(compareCatalogEntries)
       }
-      await this.writeCatalog(context.cachePath, nextCatalog)
+      await this.writeCatalog(context, nextCatalog)
     })().finally(() => {
       this.enrichmentTasks.delete(context.cacheKey)
     })
@@ -482,53 +448,36 @@ export class QgisAlgorithmCatalogService {
 
     return {
       cacheKey,
-      cachePath: path.join(this.getUserDataPath(), CATALOG_DIRECTORY_NAME, `${cacheKey}.json`),
+      databasePath: path.join(
+        this.getUserDataPath(),
+        CATALOG_DIRECTORY_NAME,
+        CATALOG_DATABASE_FILENAME
+      ),
       installation,
       allowPluginAlgorithms
     }
   }
 
-  private async readCatalog(catalogPath: string): Promise<QgisAlgorithmCatalogFile | null> {
-    try {
-      const raw = await fs.readFile(catalogPath, 'utf8')
-      const parsed = JSON.parse(raw) as QgisAlgorithmCatalogFile
-      if (
-        parsed.schemaVersion !== CATALOG_SCHEMA_VERSION ||
-        !Array.isArray(parsed.entries) ||
-        typeof parsed.cacheKey !== 'string'
-      ) {
-        return null
-      }
-
-      return {
-        ...parsed,
-        entries: parsed.entries
-          .filter((entry): entry is QgisAlgorithmCatalogEntry => isCatalogEntry(entry))
-          .map((entry) => ({
-            ...entry,
-            parameterNames: Array.isArray(entry.parameterNames) ? entry.parameterNames : [],
-            requiredParameterNames: Array.isArray(entry.requiredParameterNames)
-              ? entry.requiredParameterNames
-              : [],
-            outputParameterNames: Array.isArray(entry.outputParameterNames)
-              ? entry.outputParameterNames
-              : [],
-            searchTerms: Array.isArray(entry.searchTerms)
-              ? entry.searchTerms
-              : buildSearchTerms(entry)
-          }))
-      }
-    } catch {
+  private async readCatalog(
+    context: QgisAlgorithmCatalogContext
+  ): Promise<QgisAlgorithmCatalogFile | null> {
+    const storedCatalog = this.getCatalogStore(context.databasePath).readCatalog(context.cacheKey)
+    if (!storedCatalog) {
       return null
     }
+
+    return mapStoredCatalogToCatalogFile(storedCatalog)
   }
 
   private async writeCatalog(
-    catalogPath: string,
+    context: QgisAlgorithmCatalogContext,
     catalog: QgisAlgorithmCatalogFile
   ): Promise<void> {
-    await fs.mkdir(path.dirname(catalogPath), { recursive: true })
-    await fs.writeFile(catalogPath, JSON.stringify(catalog, null, 2), 'utf8')
+    this.getCatalogStore(context.databasePath).writeCatalog(mapCatalogFileToStoredCatalog(catalog))
+  }
+
+  private getCatalogStore(databasePath: string): QgisAlgorithmCatalogStore {
+    return new QgisAlgorithmCatalogStore(databasePath)
   }
 }
 
@@ -551,19 +500,79 @@ function createCatalogFile(
   }
 }
 
+function mapStoredCatalogToCatalogFile(
+  storedCatalog: StoredQgisAlgorithmCatalog
+): QgisAlgorithmCatalogFile {
+  return {
+    schemaVersion: CATALOG_SCHEMA_VERSION,
+    cacheKey: storedCatalog.cacheKey,
+    launcherPath: storedCatalog.launcherPath,
+    version: storedCatalog.version,
+    allowPluginAlgorithms: storedCatalog.allowPluginAlgorithms,
+    builtAt: storedCatalog.builtAt,
+    updatedAt: storedCatalog.updatedAt,
+    entries: storedCatalog.entries.map(mapStoredEntryToCatalogEntry)
+  }
+}
+
+function mapStoredEntryToCatalogEntry(
+  entry: StoredQgisAlgorithmCatalogEntry
+): QgisAlgorithmCatalogEntry {
+  return {
+    id: entry.id,
+    name: entry.name,
+    provider: entry.provider,
+    supportedForExecution: entry.supportedForExecution,
+    summary: entry.summary,
+    parameterNames: entry.parameterNames,
+    parameterTypes: entry.parameterTypes,
+    parameterDescriptions: entry.parameterDescriptions,
+    requiredParameterNames: entry.requiredParameterNames,
+    outputParameterNames: entry.outputParameterNames,
+    helpFetchedAt: entry.helpFetchedAt,
+    rawHelpPreview: entry.rawHelpPreview
+  }
+}
+
+function mapCatalogFileToStoredCatalog(
+  catalog: QgisAlgorithmCatalogFile
+): StoredQgisAlgorithmCatalog {
+  return {
+    cacheKey: catalog.cacheKey,
+    launcherPath: catalog.launcherPath,
+    version: catalog.version,
+    allowPluginAlgorithms: catalog.allowPluginAlgorithms,
+    builtAt: catalog.builtAt,
+    updatedAt: catalog.updatedAt,
+    entries: catalog.entries.map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      provider: entry.provider,
+      supportedForExecution: entry.supportedForExecution,
+      summary: entry.summary,
+      parameterNames: entry.parameterNames,
+      parameterTypes: entry.parameterTypes,
+      parameterDescriptions: entry.parameterDescriptions,
+      requiredParameterNames: entry.requiredParameterNames,
+      outputParameterNames: entry.outputParameterNames,
+      helpFetchedAt: entry.helpFetchedAt,
+      rawHelpPreview: entry.rawHelpPreview
+    }))
+  }
+}
+
 function createCatalogEntry(algorithm: QgisAlgorithmListEntry): QgisAlgorithmCatalogEntry {
-  const entry: QgisAlgorithmCatalogEntry = {
+  return {
     id: algorithm.id,
     name: algorithm.name,
     provider: algorithm.provider,
     supportedForExecution: algorithm.supportedForExecution,
     parameterNames: [],
+    parameterTypes: [],
+    parameterDescriptions: [],
     requiredParameterNames: [],
-    outputParameterNames: [],
-    searchTerms: []
+    outputParameterNames: []
   }
-  entry.searchTerms = buildSearchTerms(entry)
-  return entry
 }
 
 function applyHelpMetadata(
@@ -572,25 +581,32 @@ function applyHelpMetadata(
   rawStdout: string
 ): void {
   const parameterDefinitions = extractParameterDefinitions(parsedHelp)
-  const summary = extractHelpSummary(parsedHelp, rawStdout, entry)
-  const categoryHints = inferCategoryHints(entry, summary, parameterDefinitions)
-  const geometryHints = inferGeometryHints(summary, parameterDefinitions)
-  const layerTypeHints = inferLayerTypeHints(entry, summary, parameterDefinitions)
-
-  entry.summary = summary
+  entry.summary = extractHelpSummary(parsedHelp, rawStdout, entry)
   entry.parameterNames = parameterDefinitions.map((definition) => definition.name)
+  entry.parameterTypes = uniqueNormalizedValues(
+    parameterDefinitions.map((definition) => definition.type)
+  )
+  entry.parameterDescriptions = uniqueNormalizedValues(
+    parameterDefinitions.map((definition) => definition.description)
+  )
   entry.requiredParameterNames = parameterDefinitions
     .filter((definition) => definition.required && !definition.isOutput)
     .map((definition) => definition.name)
   entry.outputParameterNames = parameterDefinitions
     .filter((definition) => definition.isOutput)
     .map((definition) => definition.name)
-  entry.categoryHints = categoryHints
-  entry.geometryHints = geometryHints
-  entry.layerTypeHints = layerTypeHints
   entry.helpFetchedAt = new Date().toISOString()
   entry.rawHelpPreview = limitText(rawStdout)
-  entry.searchTerms = buildSearchTerms(entry)
+}
+
+function uniqueNormalizedValues(values: Array<string | undefined>): string[] {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => normalizeOptionalText(value))
+        .filter((value): value is string => typeof value === 'string')
+    )
+  ).sort()
 }
 
 function extractHelpSummary(
@@ -746,268 +762,8 @@ function inferSectionHint(pathParts: string[]): 'input' | 'output' | undefined {
   return undefined
 }
 
-function inferCategoryHints(
-  entry: Pick<QgisAlgorithmCatalogEntry, 'id' | 'name' | 'provider'>,
-  summary: string | undefined,
-  parameterDefinitions: QgisAlgorithmParameterRecord[]
-): string[] {
-  const searchText = [entry.id, entry.name, entry.provider, summary]
-    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-    .join(' ')
-    .toLowerCase()
-  const parameterNames = parameterDefinitions.map((definition) => definition.name.toLowerCase())
-  const hints = new Set<string>()
-
-  if (
-    /(sort|order|ascending|descending|rank)/.test(searchText) ||
-    parameterNames.includes('ascending')
-  ) {
-    hints.add('sorting')
-  }
-  if (/(extract|select|filter|subset)/.test(searchText)) {
-    hints.add('selection')
-  }
-  if (/(join|relate|lookup)/.test(searchText)) {
-    hints.add('join')
-  }
-  if (/(clip|intersection|intersect|overlay|union)/.test(searchText)) {
-    hints.add('overlay')
-  }
-  if (/(buffer|distance|nearest|proximity)/.test(searchText)) {
-    hints.add('proximity')
-  }
-  if (/(field|attribute|column|table)/.test(searchText)) {
-    hints.add('attributes')
-  }
-  if (/(geometry|vertices|line|polygon|point)/.test(searchText)) {
-    hints.add('geometry')
-  }
-  if (/(raster|pixel|band|tif|tiff|grid)/.test(searchText)) {
-    hints.add('raster')
-  }
-  if (/(layout|print|map export|atlas)/.test(searchText)) {
-    hints.add('layout')
-  }
-  if (/(style|symbology|qml|sld)/.test(searchText)) {
-    hints.add('style')
-  }
-  if (/(convert|translate|reproject|transform)/.test(searchText)) {
-    hints.add('conversion')
-  }
-
-  return Array.from(hints.values()).sort()
-}
-
-function inferGeometryHints(
-  summary: string | undefined,
-  parameterDefinitions: QgisAlgorithmParameterRecord[]
-): string[] {
-  const searchText = [
-    summary,
-    ...parameterDefinitions.map((definition) => definition.description || ''),
-    ...parameterDefinitions.map((definition) => definition.type || '')
-  ]
-    .join(' ')
-    .toLowerCase()
-  const hints = new Set<string>()
-
-  if (/(point|multipoint)/.test(searchText)) {
-    hints.add('Point')
-  }
-  if (/(line|string|multiline)/.test(searchText)) {
-    hints.add('LineString')
-  }
-  if (/(polygon|multipolygon)/.test(searchText)) {
-    hints.add('Polygon')
-  }
-
-  return Array.from(hints.values()).sort()
-}
-
-function inferLayerTypeHints(
-  entry: Pick<QgisAlgorithmCatalogEntry, 'provider' | 'id'>,
-  summary: string | undefined,
-  parameterDefinitions: QgisAlgorithmParameterRecord[]
-): string[] {
-  const searchText = [
-    entry.provider,
-    entry.id,
-    summary,
-    ...parameterDefinitions.map((definition) => definition.type || ''),
-    ...parameterDefinitions.map((definition) => definition.description || '')
-  ]
-    .join(' ')
-    .toLowerCase()
-  const hints = new Set<string>()
-
-  if (/(vector|feature source|feature sink|geometry)/.test(searchText)) {
-    hints.add('vector')
-  }
-  if (/(raster|band|pixel|grid)/.test(searchText)) {
-    hints.add('raster')
-  }
-  if (/(table|attribute table|csv)/.test(searchText)) {
-    hints.add('table')
-  }
-  if (/(layout|print layout)/.test(searchText)) {
-    hints.add('layout')
-  }
-
-  return Array.from(hints.values()).sort()
-}
-
-function scoreAlgorithmEntry(entry: QgisAlgorithmCatalogEntry, query: string): number {
-  const normalizedQuery = query.trim().toLowerCase()
-  const queryTerms = tokenizeText(normalizedQuery)
-  if (queryTerms.length === 0) {
-    return 0
-  }
-
-  const name = (entry.name || '').toLowerCase()
-  const id = entry.id.toLowerCase()
-  const summary = (entry.summary || '').toLowerCase()
-  const provider = (entry.provider || '').toLowerCase()
-  const searchTerms = new Set(entry.searchTerms)
-
-  let score = entry.supportedForExecution ? 8 : 0
-
-  if (name.includes(normalizedQuery)) {
-    score += 120
-  }
-  if (id.includes(normalizedQuery)) {
-    score += 96
-  }
-  if (summary.includes(normalizedQuery)) {
-    score += 72
-  }
-
-  for (const term of queryTerms) {
-    if (name.includes(term)) {
-      score += 40
-    }
-    if (id.includes(term)) {
-      score += 32
-    }
-    if (summary.includes(term)) {
-      score += 22
-    }
-    if (provider.includes(term)) {
-      score += 10
-    }
-    if (searchTerms.has(term)) {
-      score += 18
-    }
-  }
-
-  if (
-    entry.categoryHints?.includes('sorting') &&
-    /(sort|order|rank|top|longest|shortest|largest|smallest)/.test(normalizedQuery)
-  ) {
-    score += 28
-  }
-  if (
-    entry.categoryHints?.includes('selection') &&
-    /(extract|select|filter|subset|keep)/.test(normalizedQuery)
-  ) {
-    score += 24
-  }
-
-  return score
-}
-
-function buildSearchTerms(entry: Partial<QgisAlgorithmCatalogEntry>): string[] {
-  const values: string[] = [
-    entry.id || '',
-    entry.name || '',
-    entry.provider || '',
-    entry.summary || '',
-    ...(entry.categoryHints || []),
-    ...(entry.geometryHints || []),
-    ...(entry.layerTypeHints || []),
-    ...(entry.parameterNames || []),
-    ...(entry.requiredParameterNames || []),
-    ...(entry.outputParameterNames || [])
-  ]
-
-  return Array.from(new Set(values.flatMap((value) => tokenizeText(value)))).sort()
-}
-
-function tokenizeText(value: string): string[] {
-  return normalizeWhitespace(value)
-    .toLowerCase()
-    .split(/[^a-z0-9]+/u)
-    .map((token) => token.trim())
-    .filter((token) => token.length >= 2 && !STOPWORDS.has(token))
-}
-
-function normalizeAlgorithmList(
-  parsedResult: unknown,
-  stdout: string,
-  allowPluginAlgorithms: boolean
-): QgisAlgorithmListEntry[] {
-  const algorithms = new Map<string, QgisAlgorithmListEntry>()
-
-  const pushAlgorithm = (entry: { id: string; name?: string; provider?: string }): void => {
-    const id = entry.id.trim()
-    if (!id) {
-      return
-    }
-
-    algorithms.set(id, {
-      id,
-      name: normalizeOptionalText(entry.name),
-      provider: normalizeOptionalText(entry.provider) || id.split(':')[0],
-      supportedForExecution: isQgisAlgorithmApproved(id, { allowPluginAlgorithms })
-    })
-  }
-
-  for (const record of extractObjects(parsedResult)) {
-    const algorithmId = readString(record['algorithmId'], record['id'], record['name'])
-    if (!algorithmId || !isQgisAlgorithmIdentifier(algorithmId)) {
-      continue
-    }
-
-    pushAlgorithm({
-      id: algorithmId,
-      name: readString(record['display_name'], record['name'], record['label']),
-      provider: readString(record['provider'], record['providerId'])
-    })
-  }
-
-  if (algorithms.size === 0) {
-    for (const line of stdout.split(/\r?\n/u)) {
-      const match = line.trim().match(/^([A-Za-z0-9_]+:[A-Za-z0-9_]+)(?:\s+-\s+(.+))?$/)
-      if (!match?.[1]) {
-        continue
-      }
-
-      pushAlgorithm({
-        id: match[1],
-        name: match[2]
-      })
-    }
-  }
-
-  return Array.from(algorithms.values()).sort((left, right) => left.id.localeCompare(right.id))
-}
-
 function buildPluginFlags(allowPluginAlgorithms: boolean): string[] {
   return allowPluginAlgorithms ? [] : ['--skip-loading-plugins']
-}
-
-function compareScoredEntries(
-  left: { entry: QgisAlgorithmCatalogEntry; score: number },
-  right: { entry: QgisAlgorithmCatalogEntry; score: number }
-): number {
-  if (left.score !== right.score) {
-    return right.score - left.score
-  }
-
-  if (left.entry.supportedForExecution !== right.entry.supportedForExecution) {
-    return left.entry.supportedForExecution ? -1 : 1
-  }
-
-  return compareCatalogEntries(left.entry, right.entry)
 }
 
 function compareCatalogEntries(
@@ -1132,26 +888,6 @@ async function mapWithConcurrency<T>(
   await Promise.all(workers)
 }
 
-function extractObjects(value: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(value)) {
-    return value.filter(isRecord)
-  }
-
-  if (!isRecord(value)) {
-    return []
-  }
-
-  const nestedArrays = Object.values(value).filter(Array.isArray)
-  for (const nestedArray of nestedArrays) {
-    const records = (nestedArray as unknown[]).filter(isRecord)
-    if (records.length > 0) {
-      return records
-    }
-  }
-
-  return [value]
-}
-
 function safeParseJson(value: string): unknown {
   try {
     return JSON.parse(value)
@@ -1177,10 +913,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
-function isQgisAlgorithmIdentifier(value: string): boolean {
-  return /^[A-Za-z0-9_]+:[A-Za-z0-9_]+$/.test(value.trim())
-}
-
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, ' ').trim()
 }
@@ -1194,12 +926,4 @@ function limitText(value: string): string | undefined {
   return normalized.length > MAX_HELP_PREVIEW_LENGTH
     ? `${normalized.slice(0, MAX_HELP_PREVIEW_LENGTH)}...`
     : normalized
-}
-
-function isCatalogEntry(value: unknown): value is QgisAlgorithmCatalogEntry {
-  return (
-    isRecord(value) &&
-    typeof value['id'] === 'string' &&
-    typeof value['supportedForExecution'] === 'boolean'
-  )
 }

--- a/src/main/services/qgis/qgis-algorithm-catalog-store.ts
+++ b/src/main/services/qgis/qgis-algorithm-catalog-store.ts
@@ -1,0 +1,381 @@
+import fs from 'fs'
+import path from 'path'
+import { resolveMigrationPath } from '../../lib/migration-paths'
+import { buildQgisSearchMatchExpression } from './qgis-search-text'
+import { createQgisSqliteDatabase } from './qgis-sqlite'
+
+export interface StoredQgisAlgorithmCatalogEntry {
+  id: string
+  name?: string
+  provider?: string
+  supportedForExecution: boolean
+  summary?: string
+  parameterNames: string[]
+  parameterTypes: string[]
+  parameterDescriptions: string[]
+  requiredParameterNames: string[]
+  outputParameterNames: string[]
+  helpFetchedAt?: string
+  rawHelpPreview?: string
+}
+
+export interface StoredQgisAlgorithmCatalog {
+  cacheKey: string
+  launcherPath: string
+  version?: string
+  allowPluginAlgorithms: boolean
+  builtAt: string
+  updatedAt: string
+  entries: StoredQgisAlgorithmCatalogEntry[]
+}
+
+export interface StoredQgisAlgorithmCatalogSearchResult {
+  entry: StoredQgisAlgorithmCatalogEntry
+  relevance: number
+}
+
+interface CatalogRow {
+  cache_key: string
+  launcher_path: string
+  version: string | null
+  allow_plugin_algorithms: number
+  built_at: string
+  updated_at: string
+}
+
+interface EntryRow {
+  id: string
+  name: string | null
+  provider: string | null
+  supported_for_execution: number
+  summary: string | null
+  parameter_names: string
+  parameter_types: string
+  parameter_descriptions: string
+  required_parameter_names: string
+  output_parameter_names: string
+  help_fetched_at: string | null
+  raw_help_preview: string | null
+}
+
+interface SearchEntryRow extends EntryRow {
+  rank: number | null
+}
+
+const MIGRATION_FILES = ['add-qgis-algorithm-catalog-cache.sql']
+
+export class QgisAlgorithmCatalogStore {
+  constructor(private readonly databasePath: string) {}
+
+  public readCatalog(cacheKey: string): StoredQgisAlgorithmCatalog | null {
+    return this.withDatabase((db) => {
+      const row = db
+        .prepare(
+          `SELECT cache_key, launcher_path, version, allow_plugin_algorithms, built_at, updated_at
+           FROM qgis_algorithm_catalogs
+           WHERE cache_key = ?`
+        )
+        .get(cacheKey)
+
+      if (!isCatalogRow(row)) {
+        return null
+      }
+
+      const entryRows = db
+        .prepare(
+          `SELECT
+             id,
+             name,
+             provider,
+             supported_for_execution,
+             summary,
+             parameter_names,
+             parameter_types,
+             parameter_descriptions,
+             required_parameter_names,
+             output_parameter_names,
+             help_fetched_at,
+             raw_help_preview
+           FROM qgis_algorithm_entries
+           WHERE cache_key = ?
+           ORDER BY supported_for_execution DESC, sort_name, id`
+        )
+        .all(cacheKey)
+
+      return {
+        cacheKey: row.cache_key,
+        launcherPath: row.launcher_path,
+        version: normalizeOptionalText(row.version),
+        allowPluginAlgorithms: row.allow_plugin_algorithms === 1,
+        builtAt: row.built_at,
+        updatedAt: row.updated_at,
+        entries: Array.isArray(entryRows)
+          ? entryRows.filter(isEntryRow).map(mapEntryRowToCatalogEntry)
+          : []
+      }
+    })
+  }
+
+  public writeCatalog(catalog: StoredQgisAlgorithmCatalog): void {
+    this.withDatabase((db) => {
+      db.exec('BEGIN IMMEDIATE')
+      try {
+        db.prepare(
+          `INSERT INTO qgis_algorithm_catalogs (
+             cache_key,
+             launcher_path,
+             version,
+             allow_plugin_algorithms,
+             built_at,
+             updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT(cache_key) DO UPDATE SET
+             launcher_path = excluded.launcher_path,
+             version = excluded.version,
+             allow_plugin_algorithms = excluded.allow_plugin_algorithms,
+             built_at = excluded.built_at,
+             updated_at = excluded.updated_at`
+        ).run(
+          catalog.cacheKey,
+          catalog.launcherPath,
+          catalog.version || null,
+          catalog.allowPluginAlgorithms ? 1 : 0,
+          catalog.builtAt,
+          catalog.updatedAt
+        )
+
+        db.prepare('DELETE FROM qgis_algorithm_entries WHERE cache_key = ?').run(catalog.cacheKey)
+
+        const insertEntry = db.prepare(
+          `INSERT INTO qgis_algorithm_entries (
+             cache_key,
+             id,
+             name,
+             provider,
+             supported_for_execution,
+             summary,
+             parameter_names,
+             parameter_types,
+             parameter_descriptions,
+             required_parameter_names,
+             output_parameter_names,
+             help_fetched_at,
+             raw_help_preview,
+             sort_name
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+
+        for (const entry of catalog.entries) {
+          insertEntry.run(
+            catalog.cacheKey,
+            entry.id,
+            entry.name || null,
+            entry.provider || null,
+            entry.supportedForExecution ? 1 : 0,
+            entry.summary || null,
+            JSON.stringify(entry.parameterNames),
+            JSON.stringify(entry.parameterTypes),
+            JSON.stringify(entry.parameterDescriptions),
+            JSON.stringify(entry.requiredParameterNames),
+            JSON.stringify(entry.outputParameterNames),
+            entry.helpFetchedAt || null,
+            entry.rawHelpPreview || null,
+            buildSortName(entry)
+          )
+        }
+
+        db.exec('COMMIT')
+      } catch (error) {
+        db.exec('ROLLBACK')
+        throw error
+      }
+    })
+  }
+
+  public searchCatalogEntries(
+    cacheKey: string,
+    query: string,
+    options: {
+      provider?: string
+      limit?: number
+    } = {}
+  ): StoredQgisAlgorithmCatalogSearchResult[] {
+    const matchExpression = buildQgisSearchMatchExpression(query)
+    if (!matchExpression) {
+      return []
+    }
+
+    return this.withDatabase((db) => {
+      const normalizedProvider = normalizeOptionalText(options.provider)?.toLowerCase()
+      const limit = clampLimit(options.limit)
+      const params = [matchExpression, cacheKey] as unknown[]
+      const providerClause = normalizedProvider
+        ? `AND lower(coalesce(e.provider, substr(e.id, 1, instr(e.id, ':') - 1))) = ?`
+        : ''
+      if (normalizedProvider) {
+        params.push(normalizedProvider)
+      }
+      params.push(limit)
+
+      const rows = db
+        .prepare(
+          `SELECT
+             e.id,
+             e.name,
+             e.provider,
+             e.supported_for_execution,
+             e.summary,
+             e.parameter_names,
+             e.parameter_types,
+             e.parameter_descriptions,
+             e.required_parameter_names,
+             e.output_parameter_names,
+             e.help_fetched_at,
+             e.raw_help_preview,
+             bm25(qgis_algorithm_entries_fts) AS rank
+           FROM qgis_algorithm_entries_fts
+           INNER JOIN qgis_algorithm_entries e ON e.rowid = qgis_algorithm_entries_fts.rowid
+           WHERE qgis_algorithm_entries_fts MATCH ?
+             AND e.cache_key = ?
+             ${providerClause}
+           ORDER BY rank, CASE e.supported_for_execution WHEN 1 THEN 0 ELSE 1 END, e.sort_name, e.id
+           LIMIT ?`
+        )
+        .all(...params)
+
+      if (!Array.isArray(rows)) {
+        return []
+      }
+
+      return rows
+        .filter(isSearchEntryRow)
+        .map((row) => ({
+          entry: mapEntryRowToCatalogEntry(row),
+          relevance: normalizeRelevance(row.rank)
+        }))
+        .filter((result) => result.relevance > 0)
+    })
+  }
+
+  private withDatabase<T>(callback: (db: ReturnType<typeof createQgisSqliteDatabase>) => T): T {
+    fs.mkdirSync(path.dirname(this.databasePath), { recursive: true })
+    const db = createQgisSqliteDatabase(this.databasePath)
+
+    try {
+      db.exec('PRAGMA foreign_keys = ON')
+      for (const migrationFile of MIGRATION_FILES) {
+        const migrationPath = resolveMigrationPath(migrationFile, {
+          currentDir: __dirname,
+          cwd: process.cwd(),
+          resourcesPath: process.resourcesPath
+        })
+        db.exec(fs.readFileSync(migrationPath, 'utf8'))
+      }
+
+      return callback(db)
+    } finally {
+      db.close()
+    }
+  }
+}
+
+function mapEntryRowToCatalogEntry(row: EntryRow): StoredQgisAlgorithmCatalogEntry {
+  return {
+    id: row.id,
+    name: normalizeOptionalText(row.name),
+    provider: normalizeOptionalText(row.provider),
+    supportedForExecution: row.supported_for_execution === 1,
+    summary: normalizeOptionalText(row.summary),
+    parameterNames: parseStringArray(row.parameter_names),
+    parameterTypes: parseStringArray(row.parameter_types),
+    parameterDescriptions: parseStringArray(row.parameter_descriptions),
+    requiredParameterNames: parseStringArray(row.required_parameter_names),
+    outputParameterNames: parseStringArray(row.output_parameter_names),
+    helpFetchedAt: normalizeOptionalText(row.help_fetched_at),
+    rawHelpPreview: normalizeOptionalText(row.raw_help_preview)
+  }
+}
+
+function parseStringArray(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return parsed.filter((entry): entry is string => typeof entry === 'string')
+  } catch {
+    return []
+  }
+}
+
+function normalizeRelevance(rank: number | null): number {
+  if (typeof rank !== 'number' || !Number.isFinite(rank)) {
+    return 0
+  }
+
+  return -rank
+}
+
+function buildSortName(entry: Pick<StoredQgisAlgorithmCatalogEntry, 'id' | 'name'>): string {
+  return normalizeSearchText(entry.name || entry.id)
+}
+
+function normalizeSearchText(value: string | undefined): string {
+  if (!value) {
+    return ''
+  }
+
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()
+}
+
+function normalizeOptionalText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function clampLimit(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 200
+  }
+
+  return Math.max(1, Math.min(Math.floor(value), 10_000))
+}
+
+function isCatalogRow(value: unknown): value is CatalogRow {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>)['cache_key'] === 'string' &&
+    typeof (value as Record<string, unknown>)['launcher_path'] === 'string' &&
+    typeof (value as Record<string, unknown>)['allow_plugin_algorithms'] === 'number' &&
+    typeof (value as Record<string, unknown>)['built_at'] === 'string' &&
+    typeof (value as Record<string, unknown>)['updated_at'] === 'string'
+  )
+}
+
+function isEntryRow(value: unknown): value is EntryRow {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>)['id'] === 'string' &&
+    typeof (value as Record<string, unknown>)['supported_for_execution'] === 'number' &&
+    typeof (value as Record<string, unknown>)['parameter_names'] === 'string' &&
+    typeof (value as Record<string, unknown>)['parameter_types'] === 'string' &&
+    typeof (value as Record<string, unknown>)['parameter_descriptions'] === 'string' &&
+    typeof (value as Record<string, unknown>)['required_parameter_names'] === 'string' &&
+    typeof (value as Record<string, unknown>)['output_parameter_names'] === 'string'
+  )
+}
+
+function isSearchEntryRow(value: unknown): value is SearchEntryRow {
+  const recordValue = value as unknown as Record<string, unknown>
+  return (
+    isEntryRow(value) && (recordValue['rank'] === null || typeof recordValue['rank'] === 'number')
+  )
+}

--- a/src/main/services/qgis/qgis-algorithm-list.ts
+++ b/src/main/services/qgis/qgis-algorithm-list.ts
@@ -1,0 +1,153 @@
+import { isQgisAlgorithmApproved } from './qgis-algorithm-policy'
+
+export interface NormalizedQgisAlgorithmListEntry {
+  id: string
+  name?: string
+  provider?: string
+  supportedForExecution: boolean
+}
+
+export function normalizeQgisAlgorithmList(
+  parsedResult: unknown,
+  stdout: string,
+  options: {
+    allowPluginAlgorithms?: boolean
+  } = {}
+): {
+  algorithms: NormalizedQgisAlgorithmListEntry[]
+} {
+  const algorithms = new Map<string, NormalizedQgisAlgorithmListEntry>()
+
+  const pushAlgorithm = (entry: { id: string; name?: string; provider?: string }): void => {
+    const normalizedId = entry.id.trim()
+    if (!normalizedId) {
+      return
+    }
+
+    algorithms.set(normalizedId, {
+      id: normalizedId,
+      name: normalizeOptionalText(entry.name),
+      provider: normalizeOptionalText(entry.provider) || normalizedId.split(':')[0],
+      supportedForExecution: isQgisAlgorithmApproved(normalizedId, {
+        allowPluginAlgorithms: options.allowPluginAlgorithms === true
+      })
+    })
+  }
+
+  for (const providerAlgorithm of extractProviderAlgorithms(parsedResult)) {
+    pushAlgorithm(providerAlgorithm)
+  }
+
+  for (const record of extractObjects(parsedResult)) {
+    const algorithmId = readString(record['algorithmId'], record['id'], record['name'])
+    if (!algorithmId || !isQgisAlgorithmIdentifier(algorithmId)) {
+      continue
+    }
+
+    pushAlgorithm({
+      id: algorithmId,
+      name: readString(record['display_name'], record['name'], record['label']),
+      provider: readString(record['provider'], record['providerId'])
+    })
+  }
+
+  if (algorithms.size === 0) {
+    for (const line of stdout.split(/\r?\n/u)) {
+      const match = line.trim().match(/^([A-Za-z0-9_]+:[A-Za-z0-9_]+)(?:\s+-\s+(.+))?$/)
+      if (!match?.[1]) {
+        continue
+      }
+
+      pushAlgorithm({
+        id: match[1],
+        name: match[2]
+      })
+    }
+  }
+
+  return {
+    algorithms: Array.from(algorithms.values()).sort((left, right) =>
+      left.id.localeCompare(right.id)
+    )
+  }
+}
+
+function extractProviderAlgorithms(
+  parsedResult: unknown
+): Array<{ id: string; name?: string; provider?: string }> {
+  if (!isRecord(parsedResult) || !isRecord(parsedResult['providers'])) {
+    return []
+  }
+
+  const algorithms: Array<{ id: string; name?: string; provider?: string }> = []
+  for (const [providerId, providerValue] of Object.entries(parsedResult['providers'])) {
+    if (!isRecord(providerValue) || !isRecord(providerValue['algorithms'])) {
+      continue
+    }
+
+    for (const [algorithmKey, algorithmValue] of Object.entries(providerValue['algorithms'])) {
+      const algorithmRecord = isRecord(algorithmValue) ? algorithmValue : {}
+      const algorithmId =
+        readString(algorithmRecord['algorithmId'], algorithmRecord['id']) ||
+        (isQgisAlgorithmIdentifier(algorithmKey) ? algorithmKey : undefined)
+
+      if (!algorithmId || !isQgisAlgorithmIdentifier(algorithmId)) {
+        continue
+      }
+
+      algorithms.push({
+        id: algorithmId,
+        name: readString(
+          algorithmRecord['display_name'],
+          algorithmRecord['name'],
+          algorithmRecord['label']
+        ),
+        provider: readString(algorithmRecord['provider'], algorithmRecord['providerId'], providerId)
+      })
+    }
+  }
+
+  return algorithms
+}
+
+function extractObjects(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord)
+  }
+
+  if (!isRecord(value)) {
+    return []
+  }
+
+  const nestedArrays = Object.values(value).filter(Array.isArray)
+  for (const nestedArray of nestedArrays) {
+    const recordArray = (nestedArray as unknown[]).filter(isRecord)
+    if (recordArray.length > 0) {
+      return recordArray
+    }
+  }
+
+  return [value]
+}
+
+function readString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim()
+    }
+  }
+
+  return undefined
+}
+
+function normalizeOptionalText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isQgisAlgorithmIdentifier(value: string): boolean {
+  return /^[A-Za-z0-9_]+:[A-Za-z0-9_]+$/.test(value.trim())
+}

--- a/src/main/services/qgis/qgis-process-service.test.ts
+++ b/src/main/services/qgis/qgis-process-service.test.ts
@@ -192,6 +192,89 @@ describe('QgisProcessService', () => {
     }
   })
 
+  it('parses provider-scoped QGIS list output from QGIS 3.36+', async () => {
+    runQgisLauncherCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        providers: {
+          native: {
+            algorithms: {
+              'native:extractbyexpression': {
+                name: 'Extract by expression'
+              },
+              'native:extractbyattribute': {
+                name: 'Extract by attribute'
+              },
+              'native:buffer': {
+                name: 'Buffer'
+              }
+            }
+          },
+          gdal: {
+            algorithms: {
+              'gdal:translate': {
+                name: 'Convert format'
+              }
+            }
+          }
+        }
+      }),
+      stderr: '',
+      exitCode: 0,
+      durationMs: 12
+    })
+
+    const service = new QgisProcessService({
+      connectorHubService: {
+        getConfig: vi.fn(async () => ({
+          detectionMode: 'auto'
+        }))
+      } as never,
+      algorithmCatalogService: {
+        rankAlgorithms: vi.fn(async () => null),
+        warmCatalog: vi.fn()
+      } as never,
+      discoveryService: {
+        discover: vi.fn(async () => createDiscoveredInstallation())
+      } as never,
+      getUserDataPath: () => tempRoot
+    })
+
+    const result = await service.listAlgorithms({
+      query: 'extract',
+      provider: 'native',
+      limit: 2
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.parsedResult).toEqual({
+        algorithms: [
+          {
+            id: 'native:extractbyattribute',
+            name: 'Extract by attribute',
+            provider: 'native',
+            supportedForExecution: true
+          },
+          {
+            id: 'native:extractbyexpression',
+            name: 'Extract by expression',
+            provider: 'native',
+            supportedForExecution: true
+          }
+        ],
+        totalAlgorithms: 4,
+        matchedAlgorithms: 2,
+        returnedAlgorithms: 2,
+        truncated: false,
+        filters: {
+          query: 'extract',
+          provider: 'native',
+          limit: 2
+        }
+      })
+    }
+  })
+
   it('uses the algorithm catalog to rank listed algorithms when available', async () => {
     runQgisLauncherCommand.mockResolvedValue({
       stdout: JSON.stringify({
@@ -221,7 +304,6 @@ describe('QgisProcessService', () => {
           provider: 'native',
           supportedForExecution: true,
           summary: 'Sorts features by an expression.',
-          categoryHints: ['sorting'],
           parameterNames: ['INPUT', 'EXPRESSION', 'ASCENDING', 'OUTPUT']
         }
       ],
@@ -273,7 +355,6 @@ describe('QgisProcessService', () => {
             provider: 'native',
             supportedForExecution: true,
             summary: 'Sorts features by an expression.',
-            categoryHints: ['sorting'],
             parameterNames: ['INPUT', 'EXPRESSION', 'ASCENDING', 'OUTPUT']
           }
         ],

--- a/src/main/services/qgis/qgis-process-service.ts
+++ b/src/main/services/qgis/qgis-process-service.ts
@@ -16,12 +16,14 @@ import {
 import { omitUndefined } from '../../lib/omit-undefined'
 import type { ConnectorHubService } from '../connector-hub-service'
 import { LocalLayerImportService } from '../layers/local-layer-import-service'
-import { evaluateQgisAlgorithmApproval, isQgisAlgorithmApproved } from './qgis-algorithm-policy'
+import { normalizeQgisAlgorithmList } from './qgis-algorithm-list'
+import { evaluateQgisAlgorithmApproval } from './qgis-algorithm-policy'
 import { runQgisLauncherCommand } from './qgis-command-runner'
 import { QgisAlgorithmCatalogService } from './qgis-algorithm-catalog-service'
 import { QgisDiscoveryService } from './qgis-discovery-service'
 import { selectQgisArtifactsForImport } from './qgis-import-selection'
 import { QgisOutputInspector } from './qgis-output-inspector'
+import { normalizeQgisSearchText, tokenizeQgisSearchText } from './qgis-search-text'
 import type {
   QgisApplyLayerStyleRequest,
   QgisArtifactRecord,
@@ -94,9 +96,10 @@ export class QgisProcessService {
   }
 
   public async listAlgorithms(options: QgisListAlgorithmsRequest = {}): Promise<QgisProcessResult> {
+    const config = await this.getConfig()
     const result = await this.executeLauncherCommand({
       operation: 'listAlgorithms',
-      args: ['--json', ...this.buildPluginFlags(await this.getConfig()), 'list'],
+      args: ['--json', ...this.buildPluginFlags(config), 'list'],
       timeoutMs: options.timeoutMs
     })
 
@@ -104,8 +107,9 @@ export class QgisProcessService {
       return result
     }
 
-    const rawAlgorithms = normalizeAlgorithmList(result.parsedResult, result.stdout)
-    const config = await this.getConfig()
+    const rawAlgorithms = normalizeQgisAlgorithmList(result.parsedResult, result.stdout, {
+      allowPluginAlgorithms: config?.allowPluginAlgorithms === true
+    })
     const catalogResult = await this.algorithmCatalogService
       .rankAlgorithms({
         algorithms: rawAlgorithms.algorithms,
@@ -1091,7 +1095,7 @@ function normalizeProcessResult(
   }
 ): unknown {
   if (operation === 'listAlgorithms') {
-    return normalizeAlgorithmList(input.parsedResult, input.stdout)
+    return normalizeQgisAlgorithmList(input.parsedResult, input.stdout)
   }
 
   if (operation === 'describeAlgorithm') {
@@ -1105,82 +1109,23 @@ function normalizeProcessResult(
   })
 }
 
-function normalizeAlgorithmList(
-  parsedResult: unknown,
-  stdout: string
-): {
-  algorithms: Array<{
-    id: string
-    name?: string
-    provider?: string
-    supportedForExecution: boolean
-  }>
-} {
-  const algorithms = new Map<
-    string,
-    { id: string; name?: string; provider?: string; supportedForExecution: boolean }
-  >()
+interface FilterableAlgorithmEntry {
+  id: string
+  name?: string
+  provider?: string
+  supportedForExecution: boolean
+}
 
-  const pushAlgorithm = (entry: { id: string; name?: string; provider?: string }): void => {
-    const normalizedId = entry.id.trim()
-    if (!normalizedId) {
-      return
-    }
-    const provider = readString(entry.provider, normalizedId.split(':')[0])
-
-    algorithms.set(normalizedId, {
-      id: normalizedId,
-      name: entry.name,
-      provider,
-      supportedForExecution: isQgisAlgorithmApproved(normalizedId)
-    })
-  }
-
-  const records = extractObjects(parsedResult)
-  for (const record of records) {
-    const algorithmId = readString(record.algorithmId, record.id, record.name)
-    if (!algorithmId || !isQgisAlgorithmIdentifier(algorithmId)) {
-      continue
-    }
-
-    pushAlgorithm({
-      id: algorithmId,
-      name: readString(record.display_name, record.name, record.label),
-      provider: readString(record.provider, record.providerId)
-    })
-  }
-
-  if (algorithms.size === 0) {
-    for (const line of stdout.split(/\r?\n/u)) {
-      const match = line.trim().match(/^([A-Za-z0-9_]+:[A-Za-z0-9_]+)(?:\s+-\s+(.+))?$/)
-      if (!match?.[1]) {
-        continue
-      }
-
-      pushAlgorithm({
-        id: match[1],
-        name: match[2]
-      })
-    }
-  }
-
-  return {
-    algorithms: Array.from(algorithms.values()).sort((left, right) =>
-      left.id.localeCompare(right.id)
-    )
-  }
+interface RankedFallbackAlgorithmEntry {
+  algorithm: FilterableAlgorithmEntry
+  matchedTerms: number
 }
 
 function filterAlgorithmList(
   value: unknown,
   options: Pick<QgisListAlgorithmsRequest, 'query' | 'provider' | 'limit'>
 ): {
-  algorithms: Array<{
-    id: string
-    name?: string
-    provider?: string
-    supportedForExecution: boolean
-  }>
+  algorithms: FilterableAlgorithmEntry[]
   totalAlgorithms: number
   matchedAlgorithms: number
   returnedAlgorithms: number
@@ -1194,29 +1139,19 @@ function filterAlgorithmList(
   const algorithms = extractAlgorithmEntries(value)
   const normalizedQuery = normalizeOptionalText(options.query)
   const normalizedProvider = normalizeOptionalText(options.provider)?.toLowerCase()
-  const queryTerms = normalizedQuery ? normalizedQuery.toLowerCase().split(/\s+/u) : []
   const limit =
     typeof options.limit === 'number' && Number.isFinite(options.limit)
       ? Math.max(1, Math.min(Math.floor(options.limit), 200))
       : undefined
 
-  const matchedAlgorithms = algorithms.filter((algorithm) => {
+  const providerFilteredAlgorithms = algorithms.filter((algorithm) => {
     const algorithmProvider = (algorithm.provider || algorithm.id.split(':')[0] || '').toLowerCase()
-    if (normalizedProvider && algorithmProvider !== normalizedProvider) {
-      return false
-    }
-
-    if (queryTerms.length === 0) {
-      return true
-    }
-
-    const searchableText = [algorithm.id, algorithm.name, algorithm.provider]
-      .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
-      .join(' ')
-      .toLowerCase()
-
-    return queryTerms.every((term) => searchableText.includes(term))
+    return !normalizedProvider || algorithmProvider === normalizedProvider
   })
+
+  const matchedAlgorithms = normalizedQuery
+    ? searchFallbackAlgorithmEntries(providerFilteredAlgorithms, normalizedQuery)
+    : providerFilteredAlgorithms
 
   const returnedAlgorithms =
     typeof limit === 'number' ? matchedAlgorithms.slice(0, limit) : matchedAlgorithms
@@ -1246,12 +1181,7 @@ function extractAlgorithmEntries(value: unknown): Array<{
     return []
   }
 
-  const algorithms: Array<{
-    id: string
-    name?: string
-    provider?: string
-    supportedForExecution: boolean
-  }> = []
+  const algorithms: FilterableAlgorithmEntry[] = []
 
   for (const entry of value.algorithms) {
     if (!isRecord(entry)) {
@@ -1274,24 +1204,65 @@ function extractAlgorithmEntries(value: unknown): Array<{
   return algorithms
 }
 
-function extractObjects(value: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(value)) {
-    return value.filter(isRecord)
-  }
-
-  if (!isRecord(value)) {
+function searchFallbackAlgorithmEntries(
+  algorithms: FilterableAlgorithmEntry[],
+  query: string
+): FilterableAlgorithmEntry[] {
+  const queryTerms = tokenizeQgisSearchText(query)
+  if (queryTerms.length === 0) {
     return []
   }
 
-  const nestedArrays = Object.values(value).filter(Array.isArray)
-  for (const nestedArray of nestedArrays) {
-    const recordArray = (nestedArray as unknown[]).filter(isRecord)
-    if (recordArray.length > 0) {
-      return recordArray
-    }
+  return algorithms
+    .map((algorithm) => {
+      const searchableText = buildFallbackSearchText(algorithm)
+      let matchedTerms = 0
+
+      for (const term of queryTerms) {
+        if (searchableText.includes(term)) {
+          matchedTerms += 1
+        }
+      }
+
+      if (matchedTerms === 0) {
+        return null
+      }
+
+      return {
+        algorithm,
+        matchedTerms
+      }
+    })
+    .filter((result): result is RankedFallbackAlgorithmEntry => result !== null)
+    .sort(compareFallbackAlgorithmEntries)
+    .map(({ algorithm }) => algorithm)
+}
+
+function buildFallbackSearchText(algorithm: FilterableAlgorithmEntry): string {
+  return normalizeQgisSearchText(
+    [algorithm.id, algorithm.name, algorithm.provider]
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .join(' ')
+  )
+}
+
+function compareFallbackAlgorithmEntries(
+  left: RankedFallbackAlgorithmEntry,
+  right: RankedFallbackAlgorithmEntry
+): number {
+  if (left.matchedTerms !== right.matchedTerms) {
+    return right.matchedTerms - left.matchedTerms
   }
 
-  return [value]
+  if (left.algorithm.supportedForExecution !== right.algorithm.supportedForExecution) {
+    return left.algorithm.supportedForExecution ? -1 : 1
+  }
+
+  return buildFallbackSortName(left.algorithm).localeCompare(buildFallbackSortName(right.algorithm))
+}
+
+function buildFallbackSortName(algorithm: FilterableAlgorithmEntry): string {
+  return normalizeQgisSearchText(algorithm.name || algorithm.id)
 }
 
 function safeParseJson(value: string): unknown {

--- a/src/main/services/qgis/qgis-search-text.test.ts
+++ b/src/main/services/qgis/qgis-search-text.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildQgisSearchMatchExpression,
+  normalizeQgisSearchText,
+  tokenizeQgisSearchText
+} from './qgis-search-text'
+
+describe('qgis-search-text', () => {
+  it('normalizes and tokenizes natural-language search text consistently', () => {
+    expect(normalizeQgisSearchText('Sort line features by length, descending!')).toBe(
+      'sort line features by length descending'
+    )
+    expect(tokenizeQgisSearchText('Sort line features by length, descending!')).toEqual([
+      'sort',
+      'line',
+      'features',
+      'by',
+      'length',
+      'descending'
+    ])
+  })
+
+  it('builds an FTS match expression with phrase and prefix terms', () => {
+    expect(buildQgisSearchMatchExpression('sort line features by length descending')).toBe(
+      '"sort line features by length descending" OR sort* OR line* OR features* OR by* OR length* OR descending*'
+    )
+  })
+})

--- a/src/main/services/qgis/qgis-search-text.ts
+++ b/src/main/services/qgis/qgis-search-text.ts
@@ -1,0 +1,41 @@
+export function normalizeQgisSearchText(value: string | undefined): string {
+  if (!value) {
+    return ''
+  }
+
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()
+}
+
+export function tokenizeQgisSearchText(value: string): string[] {
+  return Array.from(
+    new Set(
+      normalizeQgisSearchText(value)
+        .split(' ')
+        .map((token) => token.trim())
+        .filter((token) => token.length > 0)
+    )
+  )
+}
+
+export function buildQgisSearchMatchExpression(query: string): string | null {
+  const normalizedQuery = normalizeQgisSearchText(query)
+  const queryTerms = tokenizeQgisSearchText(normalizedQuery)
+  if (!normalizedQuery || queryTerms.length === 0) {
+    return null
+  }
+
+  return buildMatchExpression(normalizedQuery, queryTerms)
+}
+
+function buildMatchExpression(normalizedQuery: string, queryTerms: string[]): string {
+  const expressions = [
+    normalizedQuery.includes(' ') ? `"${normalizedQuery}"` : null,
+    ...queryTerms.map((term) => `${term}*`)
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0)
+
+  return Array.from(new Set(expressions)).join(' OR ')
+}

--- a/src/main/services/qgis/qgis-sqlite.ts
+++ b/src/main/services/qgis/qgis-sqlite.ts
@@ -1,0 +1,55 @@
+import { createRequire } from 'node:module'
+
+const loadModule = createRequire(import.meta.url)
+
+export interface QgisSqliteDatabase {
+  exec(sql: string): void
+  prepare(sql: string): QgisSqliteStatement
+  close(): void
+}
+
+export interface QgisSqliteStatement {
+  run(...params: unknown[]): unknown
+  get(...params: unknown[]): unknown
+  all(...params: unknown[]): unknown
+}
+
+export function createQgisSqliteDatabase(location: string): QgisSqliteDatabase {
+  const betterSqliteDatabase = tryCreateBetterSqliteDatabase(location)
+  if (betterSqliteDatabase) {
+    return betterSqliteDatabase
+  }
+
+  const nodeSqliteDatabase = tryCreateNodeSqliteDatabase(location)
+  if (nodeSqliteDatabase) {
+    return nodeSqliteDatabase
+  }
+
+  throw new Error('No supported SQLite backend is available for the QGIS catalog store.')
+}
+
+function tryCreateBetterSqliteDatabase(location: string): QgisSqliteDatabase | null {
+  try {
+    const betterSqlite3 = loadModule('better-sqlite3') as
+      | (new (path: string) => QgisSqliteDatabase)
+      | {
+          default?: new (path: string) => QgisSqliteDatabase
+        }
+    const DatabaseCtor =
+      typeof betterSqlite3 === 'function' ? betterSqlite3 : betterSqlite3.default || null
+    return DatabaseCtor ? new DatabaseCtor(location) : null
+  } catch {
+    return null
+  }
+}
+
+function tryCreateNodeSqliteDatabase(location: string): QgisSqliteDatabase | null {
+  try {
+    const sqliteModule = loadModule('node:sqlite') as {
+      DatabaseSync?: new (path: string) => QgisSqliteDatabase
+    }
+    return sqliteModule.DatabaseSync ? new sqliteModule.DatabaseSync(location) : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Split qgis-algorithm-catalog-service into smaller, focused modules:
- qgis-algorithm-catalog-store: SQLite-backed persistence layer
- qgis-algorithm-list: algorithm listing and filtering logic
- qgis-search-text: full-text search utilities
- qgis-sqlite: shared SQLite helpers
- Added SQL migration for catalog cache schema with FTS5 support