### PR TITLE
refactor: MCP client service lifecycle management and runtime status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <table>
     <tr>
       <td align="center" style="background-color: #E8F5E9; border: 2px solid #4CAF50; border-radius: 8px; padding: 20px; margin: 20px 0;">
-        <h3 style="color: #2E7D32; margin: 0 0 10px 0;">🎉 v0.0.13 Released!</h3>
+        <h3 style="color: #2E7D32; margin: 0 0 10px 0;">🎉 v0.0.14 Released!</h3>
         <p style="color: #424242; font-size: 16px; margin: 0;">
-          Arion v0.0.13 is now available with bundled MCP server discovery and security approval flow.<br/>
+          Arion v0.0.14 is now available with MCP client service refactoring and runtime status tracking.<br/>
           Check out the <a href="./changelogs/v0.3.9-2025-12-29.md" style="color: #2E7D32; font-weight: bold;">release notes</a> for full details!
         </p>
       </td>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arion",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Arion is an AI agentic desktop application for geospatial analysis.",
   "license": "GPL-3.0-or-later",
   "main": "./out/main/index.js",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -257,6 +257,7 @@ async function initializeApplication(): Promise<void> {
   securityApprovalServiceInstance = new SecurityApprovalService()
   postgresqlServiceInstance = new PostgreSQLService()
   connectorHubServiceInstance = new ConnectorHubService(postgresqlServiceInstance)
+  void connectorHubServiceInstance.restoreRuntimeConnections()
   const connectorExecutionRuntime = createConnectorExecutionRuntime({
     settingsService: settingsServiceInstance,
     connectorHubService: connectorHubServiceInstance,

--- a/src/main/ipc/settings-handlers.ts
+++ b/src/main/ipc/settings-handlers.ts
@@ -1,4 +1,4 @@
-import { type IpcMain } from 'electron'
+import { BrowserWindow, type IpcMain } from 'electron'
 import {
   IpcChannels,
   OpenAIConfig,
@@ -28,7 +28,8 @@ import {
   SkillPackUploadResult,
   PluginPlatformConfig,
   PluginDiagnosticsSnapshot,
-  ConnectorPolicyConfig
+  ConnectorPolicyConfig,
+  McpServerRuntimeStatus
 } from '../../shared/ipc-types' // Adjusted path
 import { type SettingsService } from '../services/settings-service'
 import { type MCPClientService } from '../services/mcp-client-service'
@@ -377,6 +378,13 @@ export function registerSettingsIpcHandlers(
   securityApprovalService: SecurityApprovalService
 ): void {
   const genericSettingsService = settingsService as SettingsServiceWithGenericOps
+  const broadcastMcpRuntimeStatus = (status: McpServerRuntimeStatus): void => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      window.webContents.send(IpcChannels.mcpServerRuntimeStatusUpdatedEvent, status)
+    }
+  }
+
+  mcpClientService.on('runtime-status', broadcastMcpRuntimeStatus)
 
   // --- Generic SettingsService IPC Handlers (if still needed) ---
   ipcMain.handle('ctg:settings:get', async (_event, key: string) => {
@@ -602,6 +610,10 @@ export function registerSettingsIpcHandlers(
     }
   })
 
+  ipcMain.handle(IpcChannels.getMcpServerRuntimeStatuses, async () => {
+    return mcpClientService.getRuntimeStatuses()
+  })
+
   ipcMain.handle(
     IpcChannels.addMcpServerConfig,
     async (_event, config: Omit<McpServerConfig, 'id'>) => {
@@ -620,6 +632,7 @@ export function registerSettingsIpcHandlers(
         }
 
         const newConfig = await settingsService.addMcpServerConfiguration(safeConfig)
+        await mcpClientService.upsertServerConfiguration(newConfig)
         return newConfig
       } catch (error) {
         if (error instanceof Error && error.message === 'User denied MCP command approval') {
@@ -678,6 +691,9 @@ export function registerSettingsIpcHandlers(
           normalizedConfigId,
           safeUpdates
         )
+        if (updatedConfig) {
+          await mcpClientService.upsertServerConfiguration(updatedConfig)
+        }
         return updatedConfig
       } catch (error) {
         if (error instanceof Error && error.message === 'User denied MCP command approval') {
@@ -691,6 +707,9 @@ export function registerSettingsIpcHandlers(
   ipcMain.handle(IpcChannels.deleteMcpServerConfig, async (_event, configId: string) => {
     try {
       const success = await settingsService.deleteMcpServerConfiguration(configId)
+      if (success) {
+        await mcpClientService.removeServerConfiguration(configId)
+      }
       return success
     } catch {
       return false

--- a/src/main/services/connector-hub-service.test.ts
+++ b/src/main/services/connector-hub-service.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import type { PostgreSQLConnectionResult, PostgreSQLConfig } from '../../shared/ipc-types'
+
+const keytarStore = vi.hoisted(() => new Map<string, string>())
+const sqliteMocks = vi.hoisted(() => {
+  interface StoredIntegrationRow {
+    id: string
+    status: string
+    last_used: string
+    message: string | null
+    checked_at: string | null
+    has_config: number
+    public_config: string
+  }
+
+  const rowsByDbPath = new Map<string, Map<string, StoredIntegrationRow>>()
+
+  const getRows = (dbPath: string): Map<string, StoredIntegrationRow> => {
+    let rows = rowsByDbPath.get(dbPath)
+    if (!rows) {
+      rows = new Map<string, StoredIntegrationRow>()
+      rowsByDbPath.set(dbPath, rows)
+    }
+    return rows
+  }
+
+  const DatabaseMock = vi.fn(function DatabaseMock(this: unknown, dbPath: string) {
+    const rows = getRows(dbPath)
+
+    return {
+      exec: vi.fn(),
+      prepare: vi.fn((sql: string) => {
+        if (
+          sql ===
+          'SELECT id, status, last_used, message, checked_at, has_config, public_config FROM integration_configs'
+        ) {
+          return {
+            all: () => Array.from(rows.values())
+          }
+        }
+
+        if (
+          sql ===
+          'SELECT id, status, last_used, message, checked_at, has_config, public_config FROM integration_configs WHERE id = ?'
+        ) {
+          return {
+            get: (id: string) => rows.get(id)
+          }
+        }
+
+        if (sql.includes('INSERT INTO integration_configs')) {
+          return {
+            run: (
+              id: string,
+              status: string,
+              lastUsed: string,
+              message: string | null,
+              checkedAt: string | null,
+              hasConfig: number,
+              publicConfig: string
+            ) => {
+              rows.set(id, {
+                id,
+                status,
+                last_used: lastUsed,
+                message,
+                checked_at: checkedAt,
+                has_config: hasConfig,
+                public_config: publicConfig
+              })
+              return { changes: 1 }
+            }
+          }
+        }
+
+        throw new Error(`Unexpected SQL in ConnectorHubService test: ${sql}`)
+      }),
+      close: vi.fn()
+    }
+  })
+
+  return {
+    DatabaseMock,
+    reset: () => {
+      rowsByDbPath.clear()
+      DatabaseMock.mockClear()
+    }
+  }
+})
+const electronMocks = vi.hoisted(() => ({
+  getPath: vi.fn(() => os.tmpdir())
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: electronMocks.getPath
+  }
+}))
+
+vi.mock('keytar', () => ({
+  getPassword: vi.fn(async (service: string, account: string) => {
+    return keytarStore.get(`${service}:${account}`) ?? null
+  }),
+  setPassword: vi.fn(async (service: string, account: string, password: string) => {
+    keytarStore.set(`${service}:${account}`, password)
+  }),
+  deletePassword: vi.fn(async (service: string, account: string) => {
+    keytarStore.delete(`${service}:${account}`)
+    return true
+  })
+}))
+
+vi.mock('better-sqlite3', () => ({
+  default: sqliteMocks.DatabaseMock
+}))
+
+import { ConnectorHubService } from './connector-hub-service'
+
+const postgresConfig: PostgreSQLConfig = {
+  host: 'localhost',
+  port: 5432,
+  database: 'gis',
+  username: 'postgres',
+  password: 'secret',
+  ssl: false
+}
+
+const successfulCreateConnection: PostgreSQLConnectionResult = {
+  success: true,
+  version: 'PostgreSQL 16.2',
+  postgisVersion: '3.4.0',
+  message: 'Connection pool created successfully'
+}
+
+describe('ConnectorHubService runtime connection restore', () => {
+  let tempRoot: string
+
+  beforeEach(async () => {
+    keytarStore.clear()
+    sqliteMocks.reset()
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'arion-connector-hub-'))
+    electronMocks.getPath.mockReturnValue(tempRoot)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempRoot, { recursive: true, force: true })
+  })
+
+  it('restores the saved postgres runtime connection before returning states', async () => {
+    const initialPostgresqlService = {
+      createConnection: vi.fn(async () => successfulCreateConnection),
+      restoreConnection: vi.fn()
+    }
+
+    const initialHub = new ConnectorHubService(initialPostgresqlService as never)
+    await initialHub.connect('postgresql-postgis', postgresConfig)
+    initialHub.cleanup()
+
+    const restoredPostgresqlService = {
+      restoreConnection: vi.fn(async () => ({
+        success: true,
+        version: 'PostgreSQL 16.2',
+        postgisVersion: '3.4.0',
+        message: 'Connection restored successfully'
+      }))
+    }
+
+    const restoredHub = new ConnectorHubService(restoredPostgresqlService as never)
+    const states = await restoredHub.getStates()
+    const postgresState = states.find((state) => state.id === 'postgresql-postgis')
+
+    expect(restoredPostgresqlService.restoreConnection).toHaveBeenCalledWith('postgresql-postgis')
+    expect(postgresState).toMatchObject({
+      id: 'postgresql-postgis',
+      status: 'connected',
+      hasConfig: true,
+      message: 'Connection restored successfully'
+    })
+
+    restoredHub.cleanup()
+  })
+
+  it('downgrades the saved postgres state when restore fails', async () => {
+    const initialPostgresqlService = {
+      createConnection: vi.fn(async () => successfulCreateConnection),
+      restoreConnection: vi.fn()
+    }
+
+    const initialHub = new ConnectorHubService(initialPostgresqlService as never)
+    await initialHub.connect('postgresql-postgis', postgresConfig)
+    initialHub.cleanup()
+
+    const restoredPostgresqlService = {
+      restoreConnection: vi.fn(async () => ({
+        success: false,
+        message: 'password authentication failed for user "postgres"'
+      }))
+    }
+
+    const restoredHub = new ConnectorHubService(restoredPostgresqlService as never)
+    const states = await restoredHub.getStates()
+    const postgresState = states.find((state) => state.id === 'postgresql-postgis')
+
+    expect(restoredPostgresqlService.restoreConnection).toHaveBeenCalledWith('postgresql-postgis')
+    expect(postgresState).toMatchObject({
+      id: 'postgresql-postgis',
+      status: 'error',
+      hasConfig: true,
+      message: 'password authentication failed for user "postgres"'
+    })
+
+    restoredHub.cleanup()
+  })
+})

--- a/src/main/services/connector-hub-service.ts
+++ b/src/main/services/connector-hub-service.ts
@@ -35,6 +35,8 @@ export class ConnectorHubService {
   private readonly secretStore: IntegrationSecretStore
   private readonly postgresqlService: PostgreSQLService
   private readonly qgisAlgorithmCatalogService: Pick<QgisAlgorithmCatalogService, 'warmCatalog'>
+  private runtimeConnectionRestorePromise: Promise<void> | null = null
+  private runtimeConnectionRestoreAttempted = false
 
   constructor(
     postgresqlService: PostgreSQLService,
@@ -58,6 +60,8 @@ export class ConnectorHubService {
   }
 
   public async getStates(): Promise<IntegrationStateRecord[]> {
+    await this.restoreRuntimeConnections()
+
     const rows = this.stateStore.getAllRows()
     const rowById = new Map(rows.map((row) => [row.id, row]))
 
@@ -220,6 +224,23 @@ export class ConnectorHubService {
     this.stateStore.close()
   }
 
+  public async restoreRuntimeConnections(): Promise<void> {
+    if (this.runtimeConnectionRestoreAttempted) {
+      return
+    }
+
+    if (this.runtimeConnectionRestorePromise) {
+      return this.runtimeConnectionRestorePromise
+    }
+
+    this.runtimeConnectionRestorePromise = this.restoreRuntimeConnectionsInternal().finally(() => {
+      this.runtimeConnectionRestoreAttempted = true
+      this.runtimeConnectionRestorePromise = null
+    })
+
+    return this.runtimeConnectionRestorePromise
+  }
+
   private persistConnectionState(
     id: IntegrationId,
     status: IntegrationStatus,
@@ -236,6 +257,21 @@ export class ConnectorHubService {
       hasConfig: existing?.has_config === 1,
       publicConfig: existing ? parseJsonRecord(existing.public_config) : {}
     })
+  }
+
+  private async restoreRuntimeConnectionsInternal(): Promise<void> {
+    const postgresRow = this.stateStore.getRowById('postgresql-postgis')
+    if (!postgresRow || postgresRow.has_config !== 1 || postgresRow.status !== 'connected') {
+      return
+    }
+
+    const restoreResult = await this.postgresqlService.restoreConnection('postgresql-postgis')
+    this.persistConnectionState(
+      'postgresql-postgis',
+      restoreResult.success ? 'connected' : 'error',
+      restoreResult.message,
+      postgresRow.last_used
+    )
   }
 
   private warmQgisCatalog(id: IntegrationId, config: unknown): void {

--- a/src/main/services/llm-tool-service.ts
+++ b/src/main/services/llm-tool-service.ts
@@ -70,6 +70,12 @@ export class LlmToolService {
     this.externalRuntimeRegistry = externalRuntimeRegistry || null
     this.credentialInjector.setPostgresqlService(this.postgresqlService)
 
+    if (this.mcpClientService) {
+      this.mcpClientService.on('tools-updated', () => {
+        void this.refreshMcpToolsFromService()
+      })
+    }
+
     registerBuiltInTools({
       registry: this.toolRegistry,
       mapLayerTracker: this.mapLayerTracker,
@@ -148,6 +154,18 @@ export class LlmToolService {
     }
     await this.mcpClientService.ensureInitialized()
     await this.assimilateAndRegisterMcpTools()
+  }
+
+  private async refreshMcpToolsFromService(): Promise<void> {
+    if (!this.mcpClientService) {
+      return
+    }
+
+    try {
+      await this.assimilateAndRegisterMcpTools()
+    } catch {
+      void 0
+    }
   }
 
   private async getBlockedMcpToolNameSet(): Promise<Set<string>> {

--- a/src/main/services/mcp-client-service.ts
+++ b/src/main/services/mcp-client-service.ts
@@ -1,162 +1,91 @@
+import { EventEmitter } from 'events'
+import type { Stream } from 'node:stream'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
-import {
-  /* ServerInfo, */ Tool,
-  ListToolsResult,
-  Implementation,
-  ServerCapabilities
-} from '@modelcontextprotocol/sdk/types.js'
-import { SettingsService } from './settings-service'
-import { McpServerConfig, McpServerTestResult } from '../../shared/ipc-types'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import type { Implementation, ListToolsResult, Tool } from '@modelcontextprotocol/sdk/types.js'
+import type {
+  McpServerConfig,
+  McpServerRuntimeStatus,
+  McpServerTestResult
+} from '../../shared/ipc-types'
 import { ensureLocalCommandOrExecutable } from '../security/path-security'
+import { SettingsService } from './settings-service'
+import { appendMcpRuntimeDetail, summarizeMcpRuntimeFailure } from './mcp-runtime-error-utils'
 
-// Interface for a discovered MCP tool
 export interface DiscoveredMcpTool extends Tool {
-  serverId: string // To know which server this tool belongs to
+  serverId: string
 }
 
-export class MCPClientService {
+interface TransportDiagnosticsHandle {
+  dispose: () => void
+  getDetail: () => string | undefined
+}
+
+export class MCPClientService extends EventEmitter {
   private settingsService: SettingsService
   private clients: Map<string, Client> = new Map()
   private discoveredTools: DiscoveredMcpTool[] = []
-  private initializationPromise: Promise<void> | null = null // For tracking initialization
+  private runtimeStatuses: Map<string, McpServerRuntimeStatus> = new Map()
+  private serverConfigs: Map<string, McpServerConfig> = new Map()
+  private initializationPromise: Promise<void> | null = null
+  private isShuttingDown = false
 
   constructor(settingsService: SettingsService) {
+    super()
     this.settingsService = settingsService
-    // Don't await here, let it run in the background.
-    // The initialize method will handle the promise.
     this.initializationPromise = this.loadMcpServersAndDiscoverTools()
   }
 
-  // Public method to await initialization
   public async ensureInitialized(): Promise<void> {
     if (!this.initializationPromise) {
-      // This case should ideally not be hit if constructor logic is sound
       this.initializationPromise = this.loadMcpServersAndDiscoverTools()
     }
+
     return this.initializationPromise
   }
 
-  // Renamed and refactored to be the core of initialization
-  private async loadMcpServersAndDiscoverTools(): Promise<void> {
-    try {
-      const serverConfigs = await this.settingsService.getMcpServerConfigurations()
-
-      const connectionPromises = serverConfigs
-        .filter((config) => config.enabled)
-        .map((config) => this.connectToServerAndDiscover(config)) // Changed to connect and discover
-
-      await Promise.allSettled(connectionPromises) // Wait for all connections and discoveries to attempt
-    } catch {
-      // Depending on desired behavior, could re-throw or handle
-    }
+  public async reloadServerConfigurations(): Promise<void> {
+    const serverConfigs = await this.settingsService.getMcpServerConfigurations()
+    await this.syncServerConfigurations(serverConfigs)
   }
 
-  private createTransport(
-    config: Pick<McpServerConfig, 'command' | 'args' | 'url'>
-  ): StdioClientTransport | SSEClientTransport | null {
-    if (config.command) {
-      const safeCommand = ensureLocalCommandOrExecutable(config.command)
-      return new StdioClientTransport({
-        command: safeCommand,
-        args: config.args || []
-      })
-    }
+  public async upsertServerConfiguration(config: McpServerConfig): Promise<void> {
+    const previousConfig = this.serverConfigs.get(config.id)
+    this.serverConfigs.set(config.id, config)
 
-    if (config.url) {
-      try {
-        return new SSEClientTransport(new URL(config.url))
-      } catch {
-        return null
-      }
-    }
-
-    return null
-  }
-
-  // Combined connection and discovery logic for a single server
-  private async connectToServerAndDiscover(config: McpServerConfig): Promise<void> {
-    if (this.clients.has(config.id)) {
-      // Potentially re-discover tools if already connected but ensureInitialized is called again?
-      // For now, if connected, assume tools are discovered or will be handled by onclose/reconnect logic.
+    if (!config.enabled) {
+      await this.disconnectServer(config.id)
+      this.setRuntimeStatus(
+        this.buildRuntimeStatus(config, 'disabled', {
+          toolCount: 0
+        })
+      )
       return
     }
 
-    try {
-      const transport = this.createTransport(config)
-      if (!transport) {
-        return
-      }
-
-      const client = new Client({ name: 'ArionMCPClient', version: '0.1.0' })
-      await client.connect(transport)
-      this.clients.set(config.id, client)
-
-      try {
-        // Use getServerVersion() and getServerCapabilities()
-        const serverVersion: Implementation | undefined = client.getServerVersion()
-        const serverCaps: ServerCapabilities | undefined = client.getServerCapabilities()
-
-        if (serverVersion) {
-          void 0
-        } else {
-          void 0
-        }
-        if (serverCaps) {
-          void 0
-        } else {
-          void 0
-        }
-      } catch {
-        // This catch might not be strictly necessary if the getters themselves don't throw but return undefined.
-      }
-
-      // Discover tools immediately after successful connection
-      await this.discoverTools(config.id, client)
-
-      client.onclose = () => {
-        // Corrected to onclose (lowercase)
-        this.clients.delete(config.id)
-        this.discoveredTools = this.discoveredTools.filter((tool) => tool.serverId !== config.id)
-        // TODO: Potentially attempt to reconnect based on policy/settings
-      }
-    } catch {
-      void 0
+    if (!this.shouldReconnectServer(previousConfig, config)) {
+      return
     }
+
+    await this.connectToServerAndDiscover(config, true)
   }
 
-  private async discoverTools(serverId: string, client: Client): Promise<void> {
-    try {
-      const listToolsResponse = (await client.listTools()) as ListToolsResult
-      const actualToolsArray: Tool[] | undefined = listToolsResponse?.tools
+  public async removeServerConfiguration(serverId: string): Promise<void> {
+    this.serverConfigs.delete(serverId)
+    this.runtimeStatuses.delete(serverId)
+    await this.disconnectServer(serverId)
+  }
 
-      if (Array.isArray(actualToolsArray)) {
-        const newTools: DiscoveredMcpTool[] = actualToolsArray.map((tool: Tool) => ({
-          ...tool,
-          serverId: serverId
-        }))
-
-        this.discoveredTools = [
-          ...this.discoveredTools.filter((currentTool) => currentTool.serverId !== serverId),
-          ...newTools
-        ]
-      } else {
-        this.discoveredTools = this.discoveredTools.filter(
-          (currentTool) => currentTool.serverId !== serverId
-        )
-      }
-    } catch {
-      this.discoveredTools = this.discoveredTools.filter(
-        (currentTool) => currentTool.serverId !== serverId
-      )
-    }
+  public getRuntimeStatuses(): McpServerRuntimeStatus[] {
+    return Array.from(this.runtimeStatuses.values())
   }
 
   public async testServerConnection(
     config: Omit<McpServerConfig, 'id'>
   ): Promise<McpServerTestResult> {
     let client: Client | null = null
+    let diagnosticsHandle: TransportDiagnosticsHandle | null = null
 
     try {
       const transport = this.createTransport(config)
@@ -167,10 +96,11 @@ export class MCPClientService {
         }
       }
 
+      diagnosticsHandle = this.attachTransportDiagnostics(transport)
       client = new Client({ name: 'ArionMCPClient', version: '0.1.0' })
       await client.connect(transport)
 
-      const serverVersion: Implementation | undefined = client.getServerVersion()
+      const serverVersion = this.safeGetServerVersion(client)
       const listToolsResponse = (await client.listTools()) as ListToolsResult
       const tools = Array.isArray(listToolsResponse?.tools)
         ? listToolsResponse.tools.map((tool) => ({
@@ -186,11 +116,15 @@ export class MCPClientService {
         tools
       }
     } catch (error) {
+      const failure = summarizeMcpRuntimeFailure(error, diagnosticsHandle?.getDetail())
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Failed to connect to MCP server.'
+        error: failure.message,
+        details: failure.detail
       }
     } finally {
+      diagnosticsHandle?.dispose()
+
       if (client) {
         try {
           await client.close()
@@ -202,7 +136,7 @@ export class MCPClientService {
   }
 
   public getDiscoveredTools(): DiscoveredMcpTool[] {
-    return [...this.discoveredTools] // Return a copy to prevent external modification
+    return [...this.discoveredTools]
   }
 
   public async callTool(
@@ -212,40 +146,286 @@ export class MCPClientService {
   ): Promise<unknown> {
     const client = this.clients.get(serverId)
     if (!client) {
-      throw new Error(`Not connected to MCP server with ID: ${serverId}`)
-    }
-    {
-      const result = await client.callTool({ name: toolName, arguments: args })
-      return result
-    }
-  }
+      const config = this.serverConfigs.get(serverId)
+      const runtimeStatus = this.runtimeStatuses.get(serverId)
+      const serverLabel = config?.name || serverId
 
-  // Example: Connect to a dummy server for testing if needed (would be called by loadMcpServers)
-  // public async testWithDummyServer() { // Renamed to avoid confusion with constructor logic
-  //   const dummyConfig: McpServerConfig = {
-  //     id: 'dummy-server',
-  //     name: 'Dummy Echo Server',
-  //     command: 'node', // Assuming you have a simple echo MCP server script
-  //     args: ['./path/to/your/dummy-mcp-echo-server.js'], // Adjust path - MAKE SURE THIS SCRIPT EXISTS AND IS EXECUTABLE
-  //     enabled: true,
-  //   };
-  //   await this.connectToServer(dummyConfig);
-  // }
+      if (runtimeStatus?.state === 'error' && runtimeStatus.error) {
+        throw new Error(`MCP server "${serverLabel}" is unavailable: ${runtimeStatus.error}`)
+      }
+
+      throw new Error(`Not connected to MCP server "${serverLabel}".`)
+    }
+
+    return client.callTool({ name: toolName, arguments: args })
+  }
 
   public async shutdown(): Promise<void> {
-    for (const [, client] of this.clients.entries()) {
-      try {
-        await client.close()
-      } catch {
-        void 0
-      }
+    this.isShuttingDown = true
+
+    for (const serverId of Array.from(this.clients.keys())) {
+      await this.disconnectServer(serverId)
     }
+
     this.clients.clear()
     this.discoveredTools = []
+    this.runtimeStatuses.clear()
+  }
+
+  private async loadMcpServersAndDiscoverTools(): Promise<void> {
+    try {
+      const serverConfigs = await this.settingsService.getMcpServerConfigurations()
+      await this.syncServerConfigurations(serverConfigs)
+    } catch {
+      void 0
+    }
+  }
+
+  private async syncServerConfigurations(serverConfigs: McpServerConfig[]): Promise<void> {
+    const nextServerIds = new Set(serverConfigs.map((config) => config.id))
+
+    for (const existingServerId of Array.from(this.serverConfigs.keys())) {
+      if (!nextServerIds.has(existingServerId)) {
+        await this.removeServerConfiguration(existingServerId)
+      }
+    }
+
+    for (const config of serverConfigs) {
+      await this.upsertServerConfiguration(config)
+    }
+  }
+
+  private createTransport(
+    config: Pick<McpServerConfig, 'command' | 'args' | 'url'>
+  ): StdioClientTransport | SSEClientTransport | null {
+    if (config.command) {
+      const safeCommand = ensureLocalCommandOrExecutable(config.command)
+      return new StdioClientTransport({
+        command: safeCommand,
+        args: config.args || [],
+        stderr: 'pipe'
+      })
+    }
+
+    if (config.url) {
+      try {
+        return new SSEClientTransport(new URL(config.url))
+      } catch {
+        return null
+      }
+    }
+
+    return null
+  }
+
+  private attachTransportDiagnostics(
+    transport: StdioClientTransport | SSEClientTransport
+  ): TransportDiagnosticsHandle {
+    if (!(transport instanceof StdioClientTransport)) {
+      return {
+        dispose: () => void 0,
+        getDetail: () => undefined
+      }
+    }
+
+    const stderrStream = transport.stderr as Stream | null
+    if (!stderrStream) {
+      return {
+        dispose: () => void 0,
+        getDetail: () => undefined
+      }
+    }
+
+    let detail: string | undefined
+    const onData = (chunk: Buffer | string): void => {
+      const nextChunk = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+      detail = appendMcpRuntimeDetail(detail, nextChunk)
+    }
+
+    stderrStream.on('data', onData)
+
+    return {
+      dispose: () => {
+        stderrStream.removeListener('data', onData)
+      },
+      getDetail: () => detail
+    }
+  }
+
+  private async connectToServerAndDiscover(
+    config: McpServerConfig,
+    replaceExisting = false
+  ): Promise<void> {
+    if (replaceExisting) {
+      await this.disconnectServer(config.id)
+    } else if (this.clients.has(config.id)) {
+      return
+    }
+
+    const toolCount = this.discoveredTools.filter((tool) => tool.serverId === config.id).length
+    this.setRuntimeStatus(
+      this.buildRuntimeStatus(config, 'connecting', {
+        toolCount
+      })
+    )
+
+    let client: Client | null = null
+    let diagnosticsHandle: TransportDiagnosticsHandle | null = null
+
+    try {
+      const transport = this.createTransport(config)
+      if (!transport) {
+        this.setRuntimeStatus(
+          this.buildRuntimeStatus(config, 'error', {
+            toolCount: 0,
+            error: 'Provide a command for stdio or a valid URL for HTTP-based MCP servers.'
+          })
+        )
+        return
+      }
+
+      diagnosticsHandle = this.attachTransportDiagnostics(transport)
+      client = new Client({ name: 'ArionMCPClient', version: '0.1.0' })
+      await client.connect(transport)
+
+      const serverVersion = this.safeGetServerVersion(client)
+      const discoveredTools = await this.discoverTools(config.id, client)
+
+      this.clients.set(config.id, client)
+      this.replaceDiscoveredTools(config.id, discoveredTools)
+
+      client.onclose = () => {
+        this.clients.delete(config.id)
+        this.replaceDiscoveredTools(config.id, [])
+        diagnosticsHandle?.dispose()
+
+        const latestConfig = this.serverConfigs.get(config.id)
+        if (this.isShuttingDown || !latestConfig?.enabled) {
+          return
+        }
+
+        this.setRuntimeStatus(
+          this.buildRuntimeStatus(latestConfig, 'error', {
+            toolCount: 0,
+            error: 'Connection closed.',
+            detail: diagnosticsHandle?.getDetail()
+          })
+        )
+      }
+
+      this.setRuntimeStatus(
+        this.buildRuntimeStatus(config, 'connected', {
+          serverName: serverVersion?.name,
+          serverVersion: serverVersion?.version,
+          toolCount: discoveredTools.length
+        })
+      )
+    } catch (error) {
+      const failure = summarizeMcpRuntimeFailure(error, diagnosticsHandle?.getDetail())
+      this.replaceDiscoveredTools(config.id, [])
+      this.setRuntimeStatus(
+        this.buildRuntimeStatus(config, 'error', {
+          toolCount: 0,
+          error: failure.message,
+          detail: failure.detail
+        })
+      )
+
+      diagnosticsHandle?.dispose()
+
+      if (client) {
+        try {
+          await client.close()
+        } catch {
+          void 0
+        }
+      }
+    }
+  }
+
+  private async disconnectServer(serverId: string): Promise<void> {
+    const client = this.clients.get(serverId)
+    this.clients.delete(serverId)
+    this.replaceDiscoveredTools(serverId, [])
+
+    if (!client) {
+      return
+    }
+
+    client.onclose = undefined
+
+    try {
+      await client.close()
+    } catch {
+      void 0
+    }
+  }
+
+  private async discoverTools(serverId: string, client: Client): Promise<DiscoveredMcpTool[]> {
+    const listToolsResponse = (await client.listTools()) as ListToolsResult
+    const actualToolsArray = Array.isArray(listToolsResponse?.tools) ? listToolsResponse.tools : []
+
+    return actualToolsArray.map((tool: Tool) => ({
+      ...tool,
+      serverId
+    }))
+  }
+
+  private safeGetServerVersion(client: Client): Implementation | undefined {
+    try {
+      return client.getServerVersion()
+    } catch {
+      return undefined
+    }
+  }
+
+  private shouldReconnectServer(
+    previousConfig: McpServerConfig | undefined,
+    nextConfig: McpServerConfig
+  ): boolean {
+    if (!previousConfig) {
+      return true
+    }
+
+    if (!this.clients.has(nextConfig.id)) {
+      return true
+    }
+
+    if (previousConfig.command !== nextConfig.command || previousConfig.url !== nextConfig.url) {
+      return true
+    }
+
+    const previousArgs = JSON.stringify(previousConfig.args || [])
+    const nextArgs = JSON.stringify(nextConfig.args || [])
+    return previousArgs !== nextArgs
+  }
+
+  private replaceDiscoveredTools(serverId: string, nextTools: DiscoveredMcpTool[]): void {
+    this.discoveredTools = [
+      ...this.discoveredTools.filter((currentTool) => currentTool.serverId !== serverId),
+      ...nextTools
+    ]
+    this.emit('tools-updated')
+  }
+
+  private buildRuntimeStatus(
+    config: McpServerConfig,
+    state: McpServerRuntimeStatus['state'],
+    updates: Partial<
+      Omit<McpServerRuntimeStatus, 'serverId' | 'state' | 'transport' | 'updatedAt'>
+    > = {}
+  ): McpServerRuntimeStatus {
+    return {
+      serverId: config.id,
+      state,
+      transport: config.url ? 'http' : 'stdio',
+      updatedAt: new Date().toISOString(),
+      ...updates
+    }
+  }
+
+  private setRuntimeStatus(status: McpServerRuntimeStatus): void {
+    this.runtimeStatuses.set(status.serverId, status)
+    this.emit('runtime-status', status)
   }
 }
-
-// Optional: Export an instance if you want it to be a singleton managed here
-// // For actual use, an instance of SettingsService would be passed here.
-// // e.g. import { settingsServiceInstance } from './settings.service';
-// export const mcpClientService = new MCPClientService(settingsServiceInstance);

--- a/src/main/services/mcp-runtime-error-utils.test.ts
+++ b/src/main/services/mcp-runtime-error-utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendMcpRuntimeDetail,
+  normalizeMcpRuntimeDetail,
+  summarizeMcpRuntimeFailure
+} from './mcp-runtime-error-utils'
+
+describe('mcp-runtime-error-utils', () => {
+  it('prefers the last traceback line when the transport error is generic', () => {
+    const detail = `
+Traceback (most recent call last):
+  File "E:\\Coding\\open-source\\Arion\\mcp-servers\\postgresql\\postgresql_server.py", line 15, in <module>
+    import psycopg2
+ModuleNotFoundError: No module named 'psycopg2'
+    `
+
+    expect(summarizeMcpRuntimeFailure(new Error('Connection closed'), detail)).toEqual({
+      message: "ModuleNotFoundError: No module named 'psycopg2'",
+      detail: `Traceback (most recent call last):
+  File "E:\\Coding\\open-source\\Arion\\mcp-servers\\postgresql\\postgresql_server.py", line 15, in <module>
+    import psycopg2
+ModuleNotFoundError: No module named 'psycopg2'`
+    })
+  })
+
+  it('keeps the original error message when it is already specific', () => {
+    expect(summarizeMcpRuntimeFailure(new Error('spawn python ENOENT'))).toEqual({
+      message: 'spawn python ENOENT',
+      detail: undefined
+    })
+  })
+
+  it('keeps only the newest diagnostic tail when stderr grows too large', () => {
+    const appended = appendMcpRuntimeDetail('abcdef', 'ghijkl', 8)
+
+    expect(appended).toBe('efghijkl')
+  })
+
+  it('normalizes whitespace-only diagnostic output to undefined', () => {
+    expect(normalizeMcpRuntimeDetail(' \r\n\t ')).toBeUndefined()
+  })
+})

--- a/src/main/services/mcp-runtime-error-utils.ts
+++ b/src/main/services/mcp-runtime-error-utils.ts
@@ -1,0 +1,87 @@
+const ANSI_ESCAPE_CHAR = String.fromCharCode(27)
+const ANSI_ESCAPE_REGEX = new RegExp(`${ANSI_ESCAPE_CHAR}\\[[0-9;]*m`, 'g')
+
+const GENERIC_MCP_ERROR_PATTERNS = [
+  /^connection closed\.?$/i,
+  /^server closed the connection\.?$/i,
+  /^transport closed\.?$/i,
+  /^failed to connect to mcp server\.?$/i
+]
+
+export const DEFAULT_MCP_RUNTIME_DETAIL_LIMIT = 12_000
+
+export interface McpRuntimeFailure {
+  message: string
+  detail?: string
+}
+
+export function appendMcpRuntimeDetail(
+  current: string | undefined,
+  chunk: string,
+  maxChars = DEFAULT_MCP_RUNTIME_DETAIL_LIMIT
+): string | undefined {
+  const normalizedChunk = chunk.replaceAll(ANSI_ESCAPE_REGEX, '')
+  if (!normalizedChunk) {
+    return normalizeMcpRuntimeDetail(current)
+  }
+
+  const next = `${current ?? ''}${normalizedChunk}`
+  if (next.length <= maxChars) {
+    return next
+  }
+
+  return next.slice(next.length - maxChars)
+}
+
+export function normalizeMcpRuntimeDetail(detail: string | undefined): string | undefined {
+  if (!detail) {
+    return undefined
+  }
+
+  const normalized = detail
+    .replaceAll(ANSI_ESCAPE_REGEX, '')
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(/\s+$/g, ''))
+    .join('\n')
+    .trim()
+
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function getLastMeaningfulDetailLine(detail: string | undefined): string | undefined {
+  if (!detail) {
+    return undefined
+  }
+
+  const lines = detail
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+  return lines.length > 0 ? lines[lines.length - 1] : undefined
+}
+
+function isGenericMcpErrorMessage(message: string): boolean {
+  return GENERIC_MCP_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+export function summarizeMcpRuntimeFailure(
+  error: unknown,
+  detail?: string,
+  fallbackMessage = 'Failed to connect to MCP server.'
+): McpRuntimeFailure {
+  const normalizedDetail = normalizeMcpRuntimeDetail(detail)
+  const rawMessage =
+    error instanceof Error && error.message.trim().length > 0
+      ? error.message.trim()
+      : fallbackMessage
+  const detailSummary = getLastMeaningfulDetailLine(normalizedDetail)
+
+  const message = detailSummary && isGenericMcpErrorMessage(rawMessage) ? detailSummary : rawMessage
+
+  return {
+    message,
+    detail: normalizedDetail
+  }
+}

--- a/src/main/services/postgresql-service.ts
+++ b/src/main/services/postgresql-service.ts
@@ -11,6 +11,7 @@ const POSTGRESQL_CREDENTIAL_SERVICE_NAME = 'ArionPostgreSQLCredentials'
 
 export class PostgreSQLService {
   private pools: Map<string, Pool> = new Map()
+  private restorePromises: Map<string, Promise<PostgreSQLConnectionResult>> = new Map()
   private readonly maxConnections = 10
   private readonly connectionTimeout = 30000
   private readonly idleTimeout = 30000
@@ -20,53 +21,19 @@ export class PostgreSQLService {
   }
 
   async testConnection(config: PostgreSQLConfig): Promise<PostgreSQLConnectionResult> {
-    let client: PoolClient | null = null
+    const tempPool = this.createPool(config, 1)
 
     try {
-      // Create a temporary pool for testing
-      const tempPool = new Pool({
-        host: config.host,
-        port: config.port,
-        database: config.database,
-        user: config.username,
-        password: config.password,
-        ssl: config.ssl ? { rejectUnauthorized: false } : false,
-        max: 1,
-        connectionTimeoutMillis: this.connectionTimeout,
-        idleTimeoutMillis: this.idleTimeout
-      })
-
-      client = await tempPool.connect()
-
-      // Test basic connection
-      const result = await client.query('SELECT version()')
-      const version = result.rows[0]?.version || 'Unknown'
-
-      // Test PostGIS availability
-      let postgisVersion: string | null = null
-      try {
-        const postgisResult = await client.query('SELECT PostGIS_Version()')
-        postgisVersion = postgisResult.rows[0]?.postgis_version || null
-      } catch {
-        void 0
-      }
-
-      client.release()
-      client = null
-
-      await tempPool.end()
-
-      return {
-        success: true,
-        version,
-        postgisVersion,
-        message: 'Connection successful'
-      }
+      return await this.probePool(tempPool, 'Connection successful')
     } catch (error) {
       return {
         success: false,
         message: error instanceof Error ? error.message : 'Unknown connection error'
       }
+    } finally {
+      await tempPool.end().catch(() => {
+        void 0
+      })
     }
   }
 
@@ -74,57 +41,37 @@ export class PostgreSQLService {
     id: string,
     config: PostgreSQLConfig
   ): Promise<PostgreSQLConnectionResult> {
+    let candidatePool: Pool | null = null
+
     try {
-      // Close existing connection if it exists
-      await this.closeConnection(id)
-
-      // Store credentials securely
-      await this.storeCredentials(id, config)
-
-      // Create new connection pool
-      const pool = new Pool({
-        host: config.host,
-        port: config.port,
-        database: config.database,
-        user: config.username,
-        password: config.password,
-        ssl: config.ssl ? { rejectUnauthorized: false } : false,
-        max: this.maxConnections,
-        connectionTimeoutMillis: this.connectionTimeout,
-        idleTimeoutMillis: this.idleTimeout
-      })
-
-      // Test the connection
-      const testResult = await this.testConnection(config)
+      candidatePool = this.createPool(config, this.maxConnections)
+      const testResult = await this.probePool(candidatePool, 'Connection pool created successfully')
       if (!testResult.success) {
-        await pool.end()
         return testResult
       }
 
-      this.pools.set(id, pool)
+      await this.storeCredentials(id, config)
+      await this.closePool(id)
+      this.pools.set(id, candidatePool)
+      candidatePool = null
 
-      return {
-        success: true,
-        version: testResult.version,
-        postgisVersion: testResult.postgisVersion,
-        message: 'Connection pool created successfully'
-      }
+      return testResult
     } catch (error) {
       return {
         success: false,
         message: error instanceof Error ? error.message : 'Unknown error creating connection'
       }
+    } finally {
+      if (candidatePool) {
+        await candidatePool.end().catch(() => {
+          void 0
+        })
+      }
     }
   }
 
   async closeConnection(id: string): Promise<void> {
-    const pool = this.pools.get(id)
-    if (pool) {
-      await pool.end()
-      this.pools.delete(id)
-    }
-
-    // Remove stored credentials
+    await this.closePool(id)
     await this.removeCredentials(id)
   }
 
@@ -133,7 +80,7 @@ export class PostgreSQLService {
     query: string,
     params?: unknown[]
   ): Promise<PostgreSQLQueryResult> {
-    const pool = this.pools.get(id)
+    const pool = await this.ensureConnection(id)
     if (!pool) {
       return {
         success: false,
@@ -178,7 +125,7 @@ export class PostgreSQLService {
   }
 
   async executeTransaction(id: string, queries: string[]): Promise<PostgreSQLQueryResult> {
-    const pool = this.pools.get(id)
+    const pool = await this.ensureConnection(id)
     if (!pool) {
       return {
         success: false,
@@ -236,7 +183,7 @@ export class PostgreSQLService {
   }
 
   async getConnectionInfo(id: string): Promise<{ connected: boolean; config?: PostgreSQLConfig }> {
-    const pool = this.pools.get(id)
+    const pool = await this.ensureConnection(id)
     if (!pool) {
       return { connected: false }
     }
@@ -279,6 +226,28 @@ export class PostgreSQLService {
     return this.readStoredCredentials(id)
   }
 
+  async restoreConnection(id: string): Promise<PostgreSQLConnectionResult> {
+    const activePool = this.pools.get(id)
+    if (activePool) {
+      return {
+        success: true,
+        message: `Connection for ${id} is already active`
+      }
+    }
+
+    const pendingRestore = this.restorePromises.get(id)
+    if (pendingRestore) {
+      return pendingRestore
+    }
+
+    const restorePromise = this.restoreConnectionInternal(id).finally(() => {
+      this.restorePromises.delete(id)
+    })
+
+    this.restorePromises.set(id, restorePromise)
+    return restorePromise
+  }
+
   private async storeCredentials(id: string, config: PostgreSQLConfig): Promise<void> {
     {
       const credentialsKey = `${POSTGRESQL_CREDENTIAL_SERVICE_NAME}_${id}`
@@ -317,6 +286,120 @@ export class PostgreSQLService {
     try {
       const credentialsKey = `${POSTGRESQL_CREDENTIAL_SERVICE_NAME}_${id}`
       await keytar.deletePassword(POSTGRESQL_CREDENTIAL_SERVICE_NAME, credentialsKey)
+    } catch {
+      void 0
+    }
+  }
+
+  private createPool(config: PostgreSQLConfig, max: number): Pool {
+    return new Pool({
+      host: config.host,
+      port: config.port,
+      database: config.database,
+      user: config.username,
+      password: config.password,
+      ssl: config.ssl ? { rejectUnauthorized: false } : false,
+      max,
+      connectionTimeoutMillis: this.connectionTimeout,
+      idleTimeoutMillis: this.idleTimeout
+    })
+  }
+
+  private async probePool(pool: Pool, successMessage: string): Promise<PostgreSQLConnectionResult> {
+    let client: PoolClient | null = null
+
+    try {
+      client = await pool.connect()
+
+      const result = await client.query('SELECT version()')
+      const version = result.rows[0]?.version || 'Unknown'
+
+      let postgisVersion: string | null = null
+      try {
+        const postgisResult = await client.query('SELECT PostGIS_Version()')
+        postgisVersion = postgisResult.rows[0]?.postgis_version || null
+      } catch {
+        void 0
+      }
+
+      return {
+        success: true,
+        version,
+        postgisVersion,
+        message: successMessage
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown connection error'
+      }
+    } finally {
+      if (client) {
+        client.release()
+      }
+    }
+  }
+
+  private async restoreConnectionInternal(id: string): Promise<PostgreSQLConnectionResult> {
+    const config = await this.readStoredCredentials(id)
+    if (!config) {
+      return {
+        success: false,
+        message: `No saved credentials found for ${id}`
+      }
+    }
+
+    let candidatePool: Pool | null = null
+
+    try {
+      candidatePool = this.createPool(config, this.maxConnections)
+      const restoreResult = await this.probePool(candidatePool, 'Connection restored successfully')
+      if (!restoreResult.success) {
+        return restoreResult
+      }
+
+      await this.closePool(id)
+      this.pools.set(id, candidatePool)
+      candidatePool = null
+      return restoreResult
+    } catch (error) {
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown error restoring connection'
+      }
+    } finally {
+      if (candidatePool) {
+        await candidatePool.end().catch(() => {
+          void 0
+        })
+      }
+    }
+  }
+
+  private async ensureConnection(id: string): Promise<Pool | null> {
+    const activePool = this.pools.get(id)
+    if (activePool) {
+      return activePool
+    }
+
+    const restoreResult = await this.restoreConnection(id)
+    if (!restoreResult.success) {
+      return null
+    }
+
+    return this.pools.get(id) || null
+  }
+
+  private async closePool(id: string): Promise<void> {
+    const pool = this.pools.get(id)
+    if (!pool) {
+      return
+    }
+
+    this.pools.delete(id)
+
+    try {
+      await pool.end()
     } catch {
       void 0
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,7 @@ import {
   type LLMProviderType,
   type AllLLMConfigurationsForRenderer,
   type McpServerConfig,
+  type McpServerRuntimeStatus,
   type McpServerTestResult,
   type SettingsApi,
   type ChatApi,
@@ -300,6 +301,8 @@ const ctgApi = {
       ipcRenderer.invoke(IpcChannels.getAllLLMConfigs),
     getMcpServerConfigs: (): Promise<McpServerConfig[]> =>
       ipcRenderer.invoke(IpcChannels.getMcpServerConfigs),
+    getMcpServerRuntimeStatuses: (): Promise<McpServerRuntimeStatus[]> =>
+      ipcRenderer.invoke(IpcChannels.getMcpServerRuntimeStatuses),
     addMcpServerConfig: (config: Omit<McpServerConfig, 'id'>): Promise<McpServerConfig | null> =>
       ipcRenderer.invoke(IpcChannels.addMcpServerConfig, config),
     updateMcpServerConfig: (
@@ -311,6 +314,14 @@ const ctgApi = {
       ipcRenderer.invoke(IpcChannels.deleteMcpServerConfig, configId),
     testMcpServerConfig: (config: Omit<McpServerConfig, 'id'>): Promise<McpServerTestResult> =>
       ipcRenderer.invoke(IpcChannels.testMcpServerConfig, config),
+    onMcpServerRuntimeStatusUpdated: (callback: (status: McpServerRuntimeStatus) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: McpServerRuntimeStatus): void =>
+        callback(payload)
+      ipcRenderer.on(IpcChannels.mcpServerRuntimeStatusUpdatedEvent, handler)
+      return () => {
+        ipcRenderer.removeListener(IpcChannels.mcpServerRuntimeStatusUpdatedEvent, handler)
+      }
+    },
     getSystemPromptConfig: (): Promise<SystemPromptConfig> =>
       ipcRenderer.invoke(IpcChannels.getSystemPromptConfig),
     setSystemPromptConfig: (config: SystemPromptConfig): Promise<void> =>

--- a/src/renderer/src/features/settings/components/mcp-server-form.tsx
+++ b/src/renderer/src/features/settings/components/mcp-server-form.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
-import { McpServerConfig, McpServerTestResult } from '../../../../../shared/ipc-types'
+import {
+  McpServerConfig,
+  McpServerRuntimeStatus,
+  McpServerTestResult
+} from '../../../../../shared/ipc-types'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { HelpTooltip } from '@/components/ui/help-tooltip'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Checkbox } from '@/components/ui/checkbox'
-import { Textarea } from '@/components/ui/textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Select,
@@ -13,8 +17,8 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
-import { HelpTooltip } from '@/components/ui/help-tooltip'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Textarea } from '@/components/ui/textarea'
 
 interface McpServerFormProps {
   editingConfig: McpServerConfig | Omit<McpServerConfig, 'id'>
@@ -25,6 +29,7 @@ interface McpServerFormProps {
   isEditingExistingServer: boolean
   isLoading: boolean
   isTesting: boolean
+  runtimeStatus: McpServerRuntimeStatus | null
   testResult: McpServerTestResult | null
   onInputModeChange: (value: 'form' | 'json') => void
   onConnectionTypeChange: (value: 'stdio' | 'http') => void
@@ -45,6 +50,7 @@ export function McpServerForm({
   isEditingExistingServer,
   isLoading,
   isTesting,
+  runtimeStatus,
   testResult,
   onInputModeChange,
   onConnectionTypeChange,
@@ -56,6 +62,22 @@ export function McpServerForm({
   onTest
 }: McpServerFormProps): React.JSX.Element {
   const currentArgsString = Array.isArray(editingConfig.args) ? editingConfig.args.join(', ') : ''
+  const runtimeStatusLabel = runtimeStatus
+    ? {
+        connected: 'Connected',
+        connecting: 'Connecting',
+        disabled: 'Disabled',
+        error: 'Error'
+      }[runtimeStatus.state]
+    : null
+  const runtimeStatusClasses = runtimeStatus
+    ? {
+        connected: 'border-green-200 bg-green-50 text-green-900',
+        connecting: 'border-sky-200 bg-sky-50 text-sky-900',
+        disabled: 'border-border/60 bg-muted/40 text-muted-foreground',
+        error: 'border-red-200 bg-red-50 text-red-900'
+      }[runtimeStatus.state]
+    : null
 
   return (
     <div
@@ -68,6 +90,7 @@ export function McpServerForm({
           {isEditingExistingServer ? 'Edit' : 'Add'} MCP Server Configuration
         </h3>
       )}
+
       <Tabs
         value={inputMode}
         onValueChange={(value) => onInputModeChange(value as 'form' | 'json')}
@@ -171,6 +194,7 @@ export function McpServerForm({
                   as separate processes.
                 </p>
               </div>
+
               <div>
                 <div className="flex items-center gap-2 mb-1">
                   <Label htmlFor="argsString">Command Arguments</Label>
@@ -276,6 +300,51 @@ export function McpServerForm({
         </div>
       )}
 
+      {runtimeStatus && (
+        <div className={`rounded-md border p-3 ${runtimeStatusClasses}`}>
+          <p className="font-semibold">
+            Saved server status: {runtimeStatusLabel}
+            {runtimeStatus.serverName ? ` - ${runtimeStatus.serverName}` : ''}
+            {runtimeStatus.serverVersion ? ` v${runtimeStatus.serverVersion}` : ''}
+          </p>
+
+          {runtimeStatus.state === 'connected' && (
+            <p className="text-sm mt-1 text-muted-foreground">
+              {runtimeStatus.toolCount === 1
+                ? '1 tool is currently available from this server.'
+                : `${runtimeStatus.toolCount ?? 0} tools are currently available from this server.`}
+            </p>
+          )}
+
+          {runtimeStatus.state === 'connecting' && (
+            <p className="text-sm mt-1 text-muted-foreground">
+              Arion is starting this server and discovering its tools.
+            </p>
+          )}
+
+          {runtimeStatus.state === 'disabled' && (
+            <p className="text-sm mt-1 text-muted-foreground">
+              This saved server is disabled, so it will not be started.
+            </p>
+          )}
+
+          {runtimeStatus.state === 'error' && runtimeStatus.error && (
+            <p className="text-sm mt-1">{runtimeStatus.error}</p>
+          )}
+
+          {runtimeStatus.detail && (
+            <details className="mt-2">
+              <summary className="cursor-pointer select-none text-sm font-medium">
+                View runtime details
+              </summary>
+              <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-background/80 p-2 font-mono text-[11px] leading-4 text-foreground/80">
+                {runtimeStatus.detail}
+              </pre>
+            </details>
+          )}
+        </div>
+      )}
+
       {testResult && (
         <div
           className={`rounded-md border p-3 ${
@@ -286,10 +355,20 @@ export function McpServerForm({
         >
           <p className="font-semibold">
             {testResult.success ? 'Connection successful' : 'Connection failed'}
-            {testResult.serverName ? ` • ${testResult.serverName}` : ''}
+            {testResult.serverName ? ` - ${testResult.serverName}` : ''}
             {testResult.serverVersion ? ` v${testResult.serverVersion}` : ''}
           </p>
           {testResult.error && <p className="text-sm mt-1">{testResult.error}</p>}
+          {testResult.details && (
+            <details className="mt-2">
+              <summary className="cursor-pointer select-none text-sm font-medium">
+                View test details
+              </summary>
+              <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded-md bg-background/80 p-2 font-mono text-[11px] leading-4 text-foreground/80">
+                {testResult.details}
+              </pre>
+            </details>
+          )}
           {testResult.tools && testResult.tools.length > 0 && (
             <p className="text-sm mt-1 text-muted-foreground">
               Discovered tools ({testResult.tools.length}):{' '}
@@ -297,7 +376,7 @@ export function McpServerForm({
                 .slice(0, 5)
                 .map((tool) => tool.name)
                 .join(', ')}
-              {testResult.tools.length > 5 ? '…' : ''}
+              {testResult.tools.length > 5 ? '...' : ''}
             </p>
           )}
           {testResult.success && (!testResult.tools || testResult.tools.length === 0) && (

--- a/src/renderer/src/features/settings/components/mcp-settings-manager.tsx
+++ b/src/renderer/src/features/settings/components/mcp-settings-manager.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { McpServerConfig, McpServerTestResult } from '../../../../../shared/ipc-types'
+import {
+  McpServerConfig,
+  McpServerRuntimeStatus,
+  McpServerTestResult
+} from '../../../../../shared/ipc-types'
 import { Button } from '@/components/ui/button'
 import { ConfirmationDialog } from '@/components/ui/confirmation-dialog'
 import { Badge } from '@/components/ui/badge'
@@ -14,7 +18,7 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { McpServerForm } from './mcp-server-form'
 import { buildNormalizedConfig } from './mcp-config-utils'
-import { Boxes, Edit, Loader2, Trash2 } from 'lucide-react'
+import { AlertCircle, Boxes, CheckCircle2, ChevronDown, Edit, Loader2, PlugZap, Trash2 } from 'lucide-react'
 
 // Default empty state for a new/editing config
 const initialFormState: Omit<McpServerConfig, 'id'> = {
@@ -36,10 +40,20 @@ interface McpSettingsManagerProps {
   onControlsChange?: (controls: McpSettingsManagerControls) => void
 }
 
+function indexRuntimeStatuses(
+  statuses: McpServerRuntimeStatus[]
+): Record<string, McpServerRuntimeStatus> {
+  return statuses.reduce<Record<string, McpServerRuntimeStatus>>((result, status) => {
+    result[status.serverId] = status
+    return result
+  }, {})
+}
+
 export function McpSettingsManager({
   onControlsChange
 }: McpSettingsManagerProps = {}): React.JSX.Element {
   const [configs, setConfigs] = useState<McpServerConfig[]>([])
+  const [runtimeStatuses, setRuntimeStatuses] = useState<Record<string, McpServerRuntimeStatus>>({})
   const [editingConfig, setEditingConfig] = useState<
     McpServerConfig | Omit<McpServerConfig, 'id'> | null
   >(null)
@@ -60,17 +74,31 @@ export function McpSettingsManager({
     setIsLoading(true)
     setError(null)
     try {
-      const fetchedConfigs = await window.ctg.settings.getMcpServerConfigs()
+      const [fetchedConfigs, fetchedStatuses] = await Promise.all([
+        window.ctg.settings.getMcpServerConfigs(),
+        window.ctg.settings.getMcpServerRuntimeStatuses()
+      ])
       setConfigs(fetchedConfigs || [])
+      setRuntimeStatuses(indexRuntimeStatuses(fetchedStatuses || []))
     } catch {
       setError('Failed to load configurations.')
-      setConfigs([]) // Ensure configs is an array on error
+      setConfigs([])
+      setRuntimeStatuses({})
     }
     setIsLoading(false)
   }
 
   useEffect(() => {
     loadConfigs()
+  }, [])
+
+  useEffect(() => {
+    return window.ctg.settings.onMcpServerRuntimeStatusUpdated((status) => {
+      setRuntimeStatuses((previousStatuses) => ({
+        ...previousStatuses,
+        [status.serverId]: status
+      }))
+    })
   }, [])
 
   const handleInputChange = (
@@ -401,6 +429,10 @@ export function McpSettingsManager({
   const editorDescription = isEditingExistingServer
     ? 'Update this MCP server configuration and save your changes.'
     : 'Create a new MCP server configuration for your agents.'
+  const editingRuntimeStatus =
+    isEditingExistingServer && editingConfig && 'id' in editingConfig
+      ? runtimeStatuses[editingConfig.id] || null
+      : null
 
   const handleEditorOpenChange = useCallback(
     (open: boolean): void => {
@@ -446,6 +478,7 @@ export function McpSettingsManager({
             <McpServerCard
               key={config.id}
               config={config}
+              runtimeStatus={runtimeStatuses[config.id]}
               isBusy={togglingServerId === config.id}
               disableActions={isLoading || hasPendingNewServer}
               onEdit={() => handleEdit(config)}
@@ -472,6 +505,7 @@ export function McpSettingsManager({
               isEditingExistingServer={isEditingExistingServer}
               isLoading={isLoading}
               isTesting={isTesting}
+              runtimeStatus={editingRuntimeStatus}
               testResult={testResult}
               onInputModeChange={handleInputModeChange}
               onConnectionTypeChange={handleConnectionTypeChange}
@@ -503,6 +537,7 @@ export function McpSettingsManager({
 
 interface McpServerCardProps {
   config: McpServerConfig
+  runtimeStatus?: McpServerRuntimeStatus
   isBusy: boolean
   disableActions: boolean
   onEdit: () => void
@@ -512,12 +547,14 @@ interface McpServerCardProps {
 
 function McpServerCard({
   config,
+  runtimeStatus,
   isBusy,
   disableActions,
   onEdit,
   onDelete,
   onToggleEnabled
 }: McpServerCardProps): React.JSX.Element {
+  const [errorDetailsOpen, setErrorDetailsOpen] = useState(false)
   const isRemote = Boolean(config.url)
   const connectionLabel = isRemote ? 'HTTP' : 'STDIO'
   const connectionDescription = isRemote ? 'Remote MCP server' : 'Local MCP process'
@@ -527,10 +564,44 @@ function McpServerCard({
     !isRemote && Array.isArray(config.args) && config.args.length > 1
       ? config.args.slice(1).join(' ')
       : null
+  const runtimeStatusLabel = runtimeStatus
+    ? {
+        connected: 'Connected',
+        connecting: 'Connecting',
+        disabled: 'Disabled',
+        error: 'Error'
+      }[runtimeStatus.state]
+    : null
+  const runtimeStatusClasses = runtimeStatus
+    ? {
+        connected: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-400',
+        connecting: 'border-sky-500/20 bg-sky-500/10 text-sky-400',
+        disabled: 'border-border/60 bg-muted/40 text-muted-foreground',
+        error: 'border-destructive/20 bg-destructive/10 text-destructive'
+      }[runtimeStatus.state]
+    : null
+  const runtimeStatusIcon = runtimeStatus
+    ? {
+        connected: <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-400" />,
+        connecting: <Loader2 className="h-3.5 w-3.5 shrink-0 text-sky-400 animate-spin" />,
+        disabled: <PlugZap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />,
+        error: <AlertCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />
+      }[runtimeStatus.state]
+    : null
+  const runtimeStatusSummary =
+    runtimeStatus?.state === 'connected'
+      ? runtimeStatus.toolCount === 1
+        ? '1 tool discovered.'
+        : `${runtimeStatus.toolCount ?? 0} tools discovered.`
+      : runtimeStatus?.state === 'connecting'
+        ? 'Starting the server and discovering tools.'
+        : runtimeStatus?.state === 'disabled'
+          ? 'This server is saved but currently disabled.'
+          : null
 
   return (
     <Card
-      className={`overflow-hidden transition-all surface-elevated gap-0 py-0 border-border/60 hover:border-border ${
+      className={`overflow-visible transition-all surface-elevated gap-0 py-0 border-border/60 hover:border-border ${
         !config.enabled ? 'opacity-60' : ''
       }`}
     >
@@ -594,6 +665,50 @@ function McpServerCard({
             {config.url}
           </p>
         )}
+
+        {runtimeStatus && runtimeStatus.state !== 'disabled' && (
+          <div className="relative mt-3">
+            <div className={`rounded-md border text-xs ${runtimeStatusClasses}`}>
+              {runtimeStatus.state === 'error' && (runtimeStatus.error || runtimeStatus.detail) ? (
+                <div
+                  className="flex items-center gap-1.5 px-3 py-1.5 cursor-pointer select-none"
+                  onClick={() => setErrorDetailsOpen((v) => !v)}
+                >
+                  {runtimeStatusIcon}
+                  <span className="font-medium shrink-0">{runtimeStatusLabel}</span>
+                  <span className="truncate opacity-90">{runtimeStatus.error}</span>
+                  <ChevronDown className={`ml-auto h-3 w-3 shrink-0 transition-transform ${errorDetailsOpen ? 'rotate-180' : ''}`} />
+                </div>
+              ) : (
+                <div className="flex items-center gap-1.5 px-3 py-1.5">
+                  {runtimeStatusIcon}
+                  <span className="font-medium">{runtimeStatusLabel}</span>
+                  {runtimeStatus.serverName && (
+                    <span className="text-muted-foreground truncate">
+                      &middot; {runtimeStatus.serverName}
+                      {runtimeStatus.serverVersion ? ` v${runtimeStatus.serverVersion}` : ''}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {errorDetailsOpen && runtimeStatus.state === 'error' && (
+              <div className="absolute left-0 right-0 top-full z-20 mt-1 rounded-md border border-border/60 bg-card p-3 shadow-lg text-xs space-y-2">
+                {runtimeStatus.error && (
+                  <p className="text-destructive wrap-break-word text-[11px] leading-relaxed">
+                    {runtimeStatus.error}
+                  </p>
+                )}
+                {runtimeStatus.detail && (
+                  <pre className="max-h-48 overflow-auto whitespace-pre-wrap rounded bg-muted/50 p-2 font-mono text-[11px] leading-4 text-foreground/70 border border-border/40">
+                    {runtimeStatus.detail}
+                  </pre>
+                )}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="border-t border-border/40 px-4 py-2 flex items-center gap-1">
@@ -626,6 +741,7 @@ function McpServerCard({
           />
         </div>
       </div>
+
     </Card>
   )
 }

--- a/src/shared/ipc-types.ts
+++ b/src/shared/ipc-types.ts
@@ -210,9 +210,25 @@ export interface McpToolPreview {
   description?: string
 }
 
+export type McpServerRuntimeState = 'disabled' | 'connecting' | 'connected' | 'error'
+export type McpServerTransportKind = 'stdio' | 'http'
+
+export interface McpServerRuntimeStatus {
+  serverId: string
+  transport: McpServerTransportKind
+  state: McpServerRuntimeState
+  updatedAt: string
+  serverName?: string
+  serverVersion?: string
+  toolCount?: number
+  error?: string
+  detail?: string
+}
+
 export interface McpServerTestResult {
   success: boolean
   error?: string
+  details?: string
   serverName?: string
   serverVersion?: string
   tools?: McpToolPreview[]
@@ -519,10 +535,12 @@ export const IpcChannels = {
 
   // MCP Server Configuration IPC Channels
   getMcpServerConfigs: 'settings:get-mcp-server-configs',
+  getMcpServerRuntimeStatuses: 'settings:get-mcp-server-runtime-statuses',
   addMcpServerConfig: 'settings:add-mcp-server-config',
   updateMcpServerConfig: 'settings:update-mcp-server-config',
   deleteMcpServerConfig: 'settings:delete-mcp-server-config',
   testMcpServerConfig: 'settings:test-mcp-server-config',
+  mcpServerRuntimeStatusUpdatedEvent: 'ctg:mcp:runtime-status-updated',
 
   // Knowledge Base IPC Channels
   kbAddDocument: 'ctg:kb:addDocument',
@@ -677,6 +695,7 @@ export interface SettingsApi {
 
   // MCP Server Config methods
   getMcpServerConfigs: () => Promise<McpServerConfig[]>
+  getMcpServerRuntimeStatuses: () => Promise<McpServerRuntimeStatus[]>
   addMcpServerConfig: (config: Omit<McpServerConfig, 'id'>) => Promise<McpServerConfig | null>
   updateMcpServerConfig: (
     configId: string,
@@ -684,6 +703,9 @@ export interface SettingsApi {
   ) => Promise<McpServerConfig | null>
   deleteMcpServerConfig: (configId: string) => Promise<boolean>
   testMcpServerConfig: (config: Omit<McpServerConfig, 'id'>) => Promise<McpServerTestResult>
+  onMcpServerRuntimeStatusUpdated: (
+    callback: (status: McpServerRuntimeStatus) => void
+  ) => () => void
 
   // System Prompt methods
   getSystemPromptConfig: () => Promise<SystemPromptConfig>


### PR DESCRIPTION
Refactor MCP client service to support live server lifecycle operations (upsert/remove configurations), runtime error classification, and status broadcasting to the renderer. Add connector hub restore on startup, PostgreSQL service improvements, and corresponding tests.